### PR TITLE
Added support for Mustang (I,II,III-V) V.2 Series

### DIFF
--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/00.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/00.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Liquid Solo" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/01.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/01.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Whitechapel Heavy" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/02.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/02.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Intro Clean" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/03.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/03.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Bad Weather" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/04.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/04.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="E Minor Avenger" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/05.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/05.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Twin Swing" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/06.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/06.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Pawn King" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/07.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/07.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Pigs Can Fly" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/08.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/08.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Johnny Marr Clean" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/09.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/09.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Tweed Sugar" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/10.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/10.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Derek Champ" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/11.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/11.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Green Cliffs" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/12.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/12.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="60s Sparkle" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/13.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/13.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="80s Guitar Hero" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/14.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/14.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Loud as Leeds" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/15.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/15.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="LeadCommunication" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/16.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/16.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Country Deluxe" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/17.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/17.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="The Evil Bassman" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/18.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/18.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Brighton Rock" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/19.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/19.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Angry Rodent" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/20.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/20.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="JohnnyMarrTremolo" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/21.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/21.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Fusion Lead" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/22.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/22.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="C Baritone Clean" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/23.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/23.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Doom Hand" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/24.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/24.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Beauty Clean" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/25.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/25.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Movie Tremolux" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/26.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/26.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Europa" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/27.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/27.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Dirty Deluxe" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/28.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/28.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Aussie Rock" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/29.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/29.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Metal Octave" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/30.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/30.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Neil Deluxe" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/31.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/31.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Touch of Reverb" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/32.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/32.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Purple Fuzz" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/33.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/33.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Amin 3rds Solo" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/34.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/34.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Bassman Drive" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/35.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/35.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Doom Orleans" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/36.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/36.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Autumns End Scars" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/37.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/37.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Chimey Deluxe" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/38.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/38.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Cranked Princeton" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/39.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/39.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Day of Sighs" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/40.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/40.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Small Champ" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/41.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/41.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="D of SUM 41" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/42.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/42.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Bolero" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/43.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/43.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Bassman Splash" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/44.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/44.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Mike of A.A.R. 1" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/45.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/45.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Far Beyond Driven" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/46.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/46.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Four Year Strong" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/47.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/47.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Gomez Clean" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/48.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/48.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Summerset Drive" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/49.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/49.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Supersonic Burn" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/50.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/50.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Black Hole Vibe" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/51.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/51.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Super-Live Album" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/52.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/52.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Killer Cortez" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/53.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/53.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="British Steel" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/54.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/54.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Mick The Hoople" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/55.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/55.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="MSG Lead" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/56.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/56.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="The Cab Charles 2" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/57.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/57.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Alkaline Trio" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/58.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/58.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="One Bourbon" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/59.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/59.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Pasadena's Phaser" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/60.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/60.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Puppet Master" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/61.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/61.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Sic Clean" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/62.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/62.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Balls to the Wall" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/63.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/63.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Sic Delay Comp" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/64.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/64.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Rockabilly Train" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/65.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/65.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Cheap Deluxe" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/66.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/66.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Sensitive" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/67.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/67.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="South of Heaven" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/68.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/68.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Twisted Lead" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/69.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/69.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="SetYourGoals Gaia" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/70.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/70.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="This Love" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/71.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/71.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="What the Fuzz!" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/72.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/72.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Wylde '80s Lead" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/73.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/73.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Down Laid" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/74.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/74.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Juicy Clean" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/75.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/75.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Swirlin Diddy" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/76.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/76.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Live N Dangerous" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/77.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/77.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Still of the Nite" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/78.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/78.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Cold Sweat" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/79.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/79.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Active Clean" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/80.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/80.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="British Invasion" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/81.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/81.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Old Metal Clean" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/82.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/82.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Delayed Princeton" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/83.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/83.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Basic Studio Pre" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/84.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/84.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Basic '57 Champ" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/85.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/85.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Basic '57 Deluxe" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/86.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/86.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Basic '57 Twin" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/87.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/87.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Basic '59 Bassman" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/88.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/88.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Basic 65Princeton" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/89.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/89.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Basic '65 Deluxe" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/90.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/90.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Basic '65 Twin" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/91.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/91.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Basic '60s Thrift" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/92.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/92.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Basic Brit Watts" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/93.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/93.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Basic British 60s" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/94.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/94.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Basic British 70s" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/95.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/95.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Basic British 80s" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/96.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/96.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Basic Brit Colour" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/97.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/97.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Basic Super-Sonic" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/98.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/98.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Basic 90s Stack" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/99.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/FUSE/99.fuse
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FUSE>
+  <Info name="Basic 2000 Metal" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0" />
+  <PedalColors>
+    <Color ID="1">14</Color>
+    <Color ID="2">1</Color>
+    <Color ID="3">2</Color>
+    <Color ID="4">10</Color>
+  </PedalColors>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+</FUSE>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/M2_BackupName.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/M2_BackupName.fuse
@@ -1,0 +1,1 @@
+TestBackup - Mustang 3 V.2 - Fuse 2.7

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/00_Liquid Solo.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/00_Liquid Solo.fuse
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="93" POS="0" BypassState="1">
+      <Param ControlIndex="0">51456</Param>
+      <Param ControlIndex="1">47360</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">26112</Param>
+      <Param ControlIndex="4">31488</Param>
+      <Param ControlIndex="5">17664</Param>
+      <Param ControlIndex="6">51200</Param>
+      <Param ControlIndex="7">28928</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">0</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">10</Param>
+      <Param ControlIndex="13">10</Param>
+      <Param ControlIndex="14">10</Param>
+      <Param ControlIndex="15">1</Param>
+      <Param ControlIndex="16">2</Param>
+      <Param ControlIndex="17">10</Param>
+      <Param ControlIndex="18">10</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="43" POS="6" BypassState="1">
+        <Param ControlIndex="0">29696</Param>
+        <Param ControlIndex="1">31488</Param>
+        <Param ControlIndex="2">5120</Param>
+        <Param ControlIndex="3">34304</Param>
+        <Param ControlIndex="4">28928</Param>
+        <Param ControlIndex="5">0</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="36" POS="7" BypassState="1">
+        <Param ControlIndex="0">20480</Param>
+        <Param ControlIndex="1">29952</Param>
+        <Param ControlIndex="2">33024</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">44032</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Liquid Solo" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="4" HeelSetting="16384" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="1" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/01_Whitechapel Heavy.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/01_Whitechapel Heavy.fuse
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="109" POS="0" BypassState="1">
+      <Param ControlIndex="0">50944</Param>
+      <Param ControlIndex="1">22016</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">21760</Param>
+      <Param ControlIndex="4">36608</Param>
+      <Param ControlIndex="5">36608</Param>
+      <Param ControlIndex="6">51200</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">42752</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">8</Param>
+      <Param ControlIndex="13">8</Param>
+      <Param ControlIndex="14">8</Param>
+      <Param ControlIndex="15">4</Param>
+      <Param ControlIndex="16">5</Param>
+      <Param ControlIndex="17">8</Param>
+      <Param ControlIndex="18">8</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="60" POS="0" BypassState="1">
+        <Param ControlIndex="0">65280</Param>
+        <Param ControlIndex="1">29696</Param>
+        <Param ControlIndex="2">36352</Param>
+        <Param ControlIndex="3">36608</Param>
+        <Param ControlIndex="4">29696</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="58" POS="7" BypassState="1">
+        <Param ControlIndex="0">0</Param>
+        <Param ControlIndex="1">15872</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">1280</Param>
+        <Param ControlIndex="4">45056</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Whitechapel Heavy" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="2" HeelSetting="0" ToeSetting="52992" PedalMode="0" BypassEffectWhenVolumeMode="1" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/02_Intro Clean.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/02_Intro Clean.fuse
@@ -1,0 +1,91 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="117" POS="0" BypassState="1">
+      <Param ControlIndex="0">46592</Param>
+      <Param ControlIndex="1">7680</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">25344</Param>
+      <Param ControlIndex="4">45824</Param>
+      <Param ControlIndex="5">47872</Param>
+      <Param ControlIndex="6">43520</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">0</Param>
+      <Param ControlIndex="10">12544</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">5</Param>
+      <Param ControlIndex="13">5</Param>
+      <Param ControlIndex="14">5</Param>
+      <Param ControlIndex="15">1</Param>
+      <Param ControlIndex="16">2</Param>
+      <Param ControlIndex="17">9</Param>
+      <Param ControlIndex="18">5</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="7" POS="0" BypassState="1">
+        <Param ControlIndex="0">20480</Param>
+        <Param ControlIndex="1">46080</Param>
+        <Param ControlIndex="2">48128</Param>
+        <Param ControlIndex="3">15104</Param>
+        <Param ControlIndex="4">50176</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="18" POS="5" BypassState="1">
+        <Param ControlIndex="0">65280</Param>
+        <Param ControlIndex="1">3584</Param>
+        <Param ControlIndex="2">6400</Param>
+        <Param ControlIndex="3">6400</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="43" POS="6" BypassState="1">
+        <Param ControlIndex="0">18944</Param>
+        <Param ControlIndex="1">13568</Param>
+        <Param ControlIndex="2">7168</Param>
+        <Param ControlIndex="3">39680</Param>
+        <Param ControlIndex="4">21504</Param>
+        <Param ControlIndex="5">0</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="58" POS="7" BypassState="1">
+        <Param ControlIndex="0">29440</Param>
+        <Param ControlIndex="1">32768</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">50688</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Intro Clean" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="4" HeelSetting="20480" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="1" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/03_Bad Weather.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/03_Bad Weather.fuse
@@ -1,0 +1,83 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="100" POS="0" BypassState="1">
+      <Param ControlIndex="0">33024</Param>
+      <Param ControlIndex="1">30464</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32768</Param>
+      <Param ControlIndex="4">32768</Param>
+      <Param ControlIndex="5">49408</Param>
+      <Param ControlIndex="6">41472</Param>
+      <Param ControlIndex="7">65280</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">2</Param>
+      <Param ControlIndex="13">2</Param>
+      <Param ControlIndex="14">2</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">2</Param>
+      <Param ControlIndex="18">2</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="186" POS="2" BypassState="1">
+        <Param ControlIndex="0">49408</Param>
+        <Param ControlIndex="1">39424</Param>
+        <Param ControlIndex="2">33024</Param>
+        <Param ControlIndex="3">65280</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="45" POS="5" BypassState="0">
+        <Param ControlIndex="0">46848</Param>
+        <Param ControlIndex="1">58624</Param>
+        <Param ControlIndex="2">15616</Param>
+        <Param ControlIndex="3">46592</Param>
+        <Param ControlIndex="4">28416</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="11" POS="4" BypassState="1">
+        <Param ControlIndex="0">9472</Param>
+        <Param ControlIndex="1">19200</Param>
+        <Param ControlIndex="2">16640</Param>
+        <Param ControlIndex="3">65280</Param>
+        <Param ControlIndex="4">33024</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Bad Weather" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="6" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/04_E Minor Avenger.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/04_E Minor Avenger.fuse
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="109" POS="0" BypassState="1">
+      <Param ControlIndex="0">44032</Param>
+      <Param ControlIndex="1">42496</Param>
+      <Param ControlIndex="2">33024</Param>
+      <Param ControlIndex="3">22016</Param>
+      <Param ControlIndex="4">39680</Param>
+      <Param ControlIndex="5">19968</Param>
+      <Param ControlIndex="6">37376</Param>
+      <Param ControlIndex="7">36608</Param>
+      <Param ControlIndex="8">33024</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">33024</Param>
+      <Param ControlIndex="11">33024</Param>
+      <Param ControlIndex="12">4</Param>
+      <Param ControlIndex="13">8</Param>
+      <Param ControlIndex="14">8</Param>
+      <Param ControlIndex="15">2</Param>
+      <Param ControlIndex="16">3</Param>
+      <Param ControlIndex="17">8</Param>
+      <Param ControlIndex="18">8</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="2" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="4127" POS="4" BypassState="1">
+        <Param ControlIndex="0">17408</Param>
+        <Param ControlIndex="1">9</Param>
+        <Param ControlIndex="2">4</Param>
+        <Param ControlIndex="3">5</Param>
+        <Param ControlIndex="4">51200</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="22" POS="5" BypassState="1">
+        <Param ControlIndex="0">20736</Param>
+        <Param ControlIndex="1">33024</Param>
+        <Param ControlIndex="2">7424</Param>
+        <Param ControlIndex="3">33024</Param>
+        <Param ControlIndex="4">33024</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="E Minor Avenger" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="3" HeelSetting="0" ToeSetting="22272" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/05_Twin Swing.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/05_Twin Swing.fuse
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="246" POS="0" BypassState="1">
+      <Param ControlIndex="0">50176</Param>
+      <Param ControlIndex="1">30720</Param>
+      <Param ControlIndex="2">33024</Param>
+      <Param ControlIndex="3">33024</Param>
+      <Param ControlIndex="4">31744</Param>
+      <Param ControlIndex="5">22784</Param>
+      <Param ControlIndex="6">45568</Param>
+      <Param ControlIndex="7">48384</Param>
+      <Param ControlIndex="8">33024</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">33024</Param>
+      <Param ControlIndex="11">33024</Param>
+      <Param ControlIndex="12">14</Param>
+      <Param ControlIndex="13">14</Param>
+      <Param ControlIndex="14">14</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">9</Param>
+      <Param ControlIndex="18">14</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="0"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="4" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="0"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="76" POS="4" BypassState="1">
+        <Param ControlIndex="0">33536</Param>
+        <Param ControlIndex="1">33024</Param>
+        <Param ControlIndex="2">33024</Param>
+        <Param ControlIndex="3">33024</Param>
+        <Param ControlIndex="4">33024</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Twin Swing" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="6" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/06_Pawn King.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/06_Pawn King.fuse
@@ -1,0 +1,76 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="249" POS="0" BypassState="1">
+      <Param ControlIndex="0">44032</Param>
+      <Param ControlIndex="1">60928</Param>
+      <Param ControlIndex="2">33024</Param>
+      <Param ControlIndex="3">33024</Param>
+      <Param ControlIndex="4">38912</Param>
+      <Param ControlIndex="5">33024</Param>
+      <Param ControlIndex="6">40192</Param>
+      <Param ControlIndex="7">33024</Param>
+      <Param ControlIndex="8">33024</Param>
+      <Param ControlIndex="9">0</Param>
+      <Param ControlIndex="10">33024</Param>
+      <Param ControlIndex="11">33024</Param>
+      <Param ControlIndex="12">4</Param>
+      <Param ControlIndex="13">15</Param>
+      <Param ControlIndex="14">15</Param>
+      <Param ControlIndex="15">1</Param>
+      <Param ControlIndex="16">2</Param>
+      <Param ControlIndex="17">1</Param>
+      <Param ControlIndex="18">15</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="271" POS="0" BypassState="1">
+        <Param ControlIndex="0">17408</Param>
+        <Param ControlIndex="1">48640</Param>
+        <Param ControlIndex="2">17152</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="4" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="0"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="76" POS="4" BypassState="1">
+        <Param ControlIndex="0">33536</Param>
+        <Param ControlIndex="1">33024</Param>
+        <Param ControlIndex="2">33024</Param>
+        <Param ControlIndex="3">33024</Param>
+        <Param ControlIndex="4">33024</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Pawn King" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="6" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/07_Pigs Can Fly.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/07_Pigs Can Fly.fuse
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="255" POS="0" BypassState="1">
+      <Param ControlIndex="0">47616</Param>
+      <Param ControlIndex="1">40192</Param>
+      <Param ControlIndex="2">33024</Param>
+      <Param ControlIndex="3">65280</Param>
+      <Param ControlIndex="4">45056</Param>
+      <Param ControlIndex="5">43264</Param>
+      <Param ControlIndex="6">42496</Param>
+      <Param ControlIndex="7">34560</Param>
+      <Param ControlIndex="8">33024</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">33024</Param>
+      <Param ControlIndex="11">33024</Param>
+      <Param ControlIndex="12">4</Param>
+      <Param ControlIndex="13">17</Param>
+      <Param ControlIndex="14">17</Param>
+      <Param ControlIndex="15">2</Param>
+      <Param ControlIndex="16">3</Param>
+      <Param ControlIndex="17">10</Param>
+      <Param ControlIndex="18">17</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="271" POS="0" BypassState="1">
+        <Param ControlIndex="0">44032</Param>
+        <Param ControlIndex="1">40192</Param>
+        <Param ControlIndex="2">17664</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="18" POS="4" BypassState="1">
+        <Param ControlIndex="0">30976</Param>
+        <Param ControlIndex="1">0</Param>
+        <Param ControlIndex="2">36096</Param>
+        <Param ControlIndex="3">6912</Param>
+        <Param ControlIndex="4">33024</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="43" POS="6" BypassState="1">
+        <Param ControlIndex="0">25344</Param>
+        <Param ControlIndex="1">34048</Param>
+        <Param ControlIndex="2">10496</Param>
+        <Param ControlIndex="3">18176</Param>
+        <Param ControlIndex="4">33024</Param>
+        <Param ControlIndex="5">256</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="36" POS="7" BypassState="1">
+        <Param ControlIndex="0">20992</Param>
+        <Param ControlIndex="1">26112</Param>
+        <Param ControlIndex="2">42496</Param>
+        <Param ControlIndex="3">20992</Param>
+        <Param ControlIndex="4">65280</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Pigs Can Fly" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="6" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/08_Johnny Marr Clean.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/08_Johnny Marr Clean.fuse
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="106" POS="0" BypassState="1">
+      <Param ControlIndex="0">43520</Param>
+      <Param ControlIndex="1">21760</Param>
+      <Param ControlIndex="2">0</Param>
+      <Param ControlIndex="3">65280</Param>
+      <Param ControlIndex="4">39168</Param>
+      <Param ControlIndex="5">52224</Param>
+      <Param ControlIndex="6">19456</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">4</Param>
+      <Param ControlIndex="13">4</Param>
+      <Param ControlIndex="14">4</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">4</Param>
+      <Param ControlIndex="18">4</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="18" POS="5" BypassState="1">
+        <Param ControlIndex="0">65280</Param>
+        <Param ControlIndex="1">3584</Param>
+        <Param ControlIndex="2">6400</Param>
+        <Param ControlIndex="3">6400</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="42" POS="6" BypassState="1">
+        <Param ControlIndex="0">32000</Param>
+        <Param ControlIndex="1">34816</Param>
+        <Param ControlIndex="2">7168</Param>
+        <Param ControlIndex="3">25344</Param>
+        <Param ControlIndex="4">65280</Param>
+        <Param ControlIndex="5">32768</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="11" POS="7" BypassState="1">
+        <Param ControlIndex="0">32768</Param>
+        <Param ControlIndex="1">35584</Param>
+        <Param ControlIndex="2">18688</Param>
+        <Param ControlIndex="3">65280</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Johnny Marr Clean" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="4" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="1" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="2" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/09_Tweed Sugar.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/09_Tweed Sugar.fuse
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="246" POS="0" BypassState="1">
+      <Param ControlIndex="0">39168</Param>
+      <Param ControlIndex="1">37376</Param>
+      <Param ControlIndex="2">33024</Param>
+      <Param ControlIndex="3">33024</Param>
+      <Param ControlIndex="4">40192</Param>
+      <Param ControlIndex="5">31488</Param>
+      <Param ControlIndex="6">40192</Param>
+      <Param ControlIndex="7">48384</Param>
+      <Param ControlIndex="8">33024</Param>
+      <Param ControlIndex="9">0</Param>
+      <Param ControlIndex="10">33024</Param>
+      <Param ControlIndex="11">33024</Param>
+      <Param ControlIndex="12">4</Param>
+      <Param ControlIndex="13">14</Param>
+      <Param ControlIndex="14">14</Param>
+      <Param ControlIndex="15">1</Param>
+      <Param ControlIndex="16">2</Param>
+      <Param ControlIndex="17">9</Param>
+      <Param ControlIndex="18">14</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="7" POS="0" BypassState="1">
+        <Param ControlIndex="0">31488</Param>
+        <Param ControlIndex="1">3840</Param>
+        <Param ControlIndex="2">20224</Param>
+        <Param ControlIndex="3">32512</Param>
+        <Param ControlIndex="4">32512</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="0"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="38" POS="7" BypassState="1">
+        <Param ControlIndex="0">9984</Param>
+        <Param ControlIndex="1">33024</Param>
+        <Param ControlIndex="2">33024</Param>
+        <Param ControlIndex="3">33024</Param>
+        <Param ControlIndex="4">33024</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Tweed Sugar" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="6" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/10_Derek Champ.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/10_Derek Champ.fuse
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="124" POS="0" BypassState="1">
+      <Param ControlIndex="0">44544</Param>
+      <Param ControlIndex="1">29184</Param>
+      <Param ControlIndex="2">0</Param>
+      <Param ControlIndex="3">65280</Param>
+      <Param ControlIndex="4">65280</Param>
+      <Param ControlIndex="5">50944</Param>
+      <Param ControlIndex="6">14336</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">12</Param>
+      <Param ControlIndex="13">12</Param>
+      <Param ControlIndex="14">12</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">5</Param>
+      <Param ControlIndex="18">12</Param>
+      <Param ControlIndex="19">2</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="75" POS="7" BypassState="1">
+        <Param ControlIndex="0">8704</Param>
+        <Param ControlIndex="1">32768</Param>
+        <Param ControlIndex="2">37120</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">65280</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Derek Champ" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="1" HeelSetting="24576" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="1" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/11_Green Cliffs.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/11_Green Cliffs.fuse
@@ -1,0 +1,84 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="94" POS="0" BypassState="1">
+      <Param ControlIndex="0">43776</Param>
+      <Param ControlIndex="1">22272</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32000</Param>
+      <Param ControlIndex="4">0</Param>
+      <Param ControlIndex="5">40704</Param>
+      <Param ControlIndex="6">65280</Param>
+      <Param ControlIndex="7">0</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">0</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">9</Param>
+      <Param ControlIndex="13">9</Param>
+      <Param ControlIndex="14">9</Param>
+      <Param ControlIndex="15">1</Param>
+      <Param ControlIndex="16">2</Param>
+      <Param ControlIndex="17">6</Param>
+      <Param ControlIndex="18">9</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="186" POS="0" BypassState="1">
+        <Param ControlIndex="0">30976</Param>
+        <Param ControlIndex="1">65280</Param>
+        <Param ControlIndex="2">35840</Param>
+        <Param ControlIndex="3">65280</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="43" POS="6" BypassState="1">
+        <Param ControlIndex="0">17664</Param>
+        <Param ControlIndex="1">16384</Param>
+        <Param ControlIndex="2">10752</Param>
+        <Param ControlIndex="3">25088</Param>
+        <Param ControlIndex="4">44032</Param>
+        <Param ControlIndex="5">0</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="58" POS="7" BypassState="1">
+        <Param ControlIndex="0">8192</Param>
+        <Param ControlIndex="1">18432</Param>
+        <Param ControlIndex="2">43776</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">65280</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Green Cliffs" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="6" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/12_60s Sparkle.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/12_60s Sparkle.fuse
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="97" POS="0" BypassState="1">
+      <Param ControlIndex="0">40960</Param>
+      <Param ControlIndex="1">22016</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">41472</Param>
+      <Param ControlIndex="4">39424</Param>
+      <Param ControlIndex="5">32768</Param>
+      <Param ControlIndex="6">30720</Param>
+      <Param ControlIndex="7">0</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">7</Param>
+      <Param ControlIndex="13">7</Param>
+      <Param ControlIndex="14">7</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">7</Param>
+      <Param ControlIndex="18">7</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="7" POS="0" BypassState="1">
+        <Param ControlIndex="0">29184</Param>
+        <Param ControlIndex="1">11008</Param>
+        <Param ControlIndex="2">65280</Param>
+        <Param ControlIndex="3">0</Param>
+        <Param ControlIndex="4">0</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="36" POS="7" BypassState="1">
+        <Param ControlIndex="0">20992</Param>
+        <Param ControlIndex="1">26112</Param>
+        <Param ControlIndex="2">42496</Param>
+        <Param ControlIndex="3">20992</Param>
+        <Param ControlIndex="4">65280</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="60s Sparkle" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="5" HeelSetting="4096" ToeSetting="44800" PedalMode="0" BypassEffectWhenVolumeMode="1" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/13_80s Guitar Hero.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/13_80s Guitar Hero.fuse
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="241" POS="0" BypassState="1">
+      <Param ControlIndex="0">65280</Param>
+      <Param ControlIndex="1">36864</Param>
+      <Param ControlIndex="2">33024</Param>
+      <Param ControlIndex="3">33024</Param>
+      <Param ControlIndex="4">33024</Param>
+      <Param ControlIndex="5">33024</Param>
+      <Param ControlIndex="6">33024</Param>
+      <Param ControlIndex="7">33024</Param>
+      <Param ControlIndex="8">33024</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">33024</Param>
+      <Param ControlIndex="11">33024</Param>
+      <Param ControlIndex="12">13</Param>
+      <Param ControlIndex="13">13</Param>
+      <Param ControlIndex="14">13</Param>
+      <Param ControlIndex="15">2</Param>
+      <Param ControlIndex="16">3</Param>
+      <Param ControlIndex="17">10</Param>
+      <Param ControlIndex="18">13</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="272" POS="0" BypassState="1">
+        <Param ControlIndex="0">44288</Param>
+        <Param ControlIndex="1">65280</Param>
+        <Param ControlIndex="2">33024</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="18" POS="5" BypassState="1">
+        <Param ControlIndex="0">65280</Param>
+        <Param ControlIndex="1">3840</Param>
+        <Param ControlIndex="2">6912</Param>
+        <Param ControlIndex="3">6912</Param>
+        <Param ControlIndex="4">33024</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="42" POS="6" BypassState="1">
+        <Param ControlIndex="0">4608</Param>
+        <Param ControlIndex="1">35072</Param>
+        <Param ControlIndex="2">7424</Param>
+        <Param ControlIndex="3">25600</Param>
+        <Param ControlIndex="4">65280</Param>
+        <Param ControlIndex="5">33024</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="58" POS="7" BypassState="1">
+        <Param ControlIndex="0">0</Param>
+        <Param ControlIndex="1">15872</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">1280</Param>
+        <Param ControlIndex="4">45056</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="80s Guitar Hero" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="2" HeelSetting="0" ToeSetting="52992" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/14_Loud as Leeds.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/14_Loud as Leeds.fuse
@@ -1,0 +1,76 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="255" POS="0" BypassState="1">
+      <Param ControlIndex="0">47616</Param>
+      <Param ControlIndex="1">57088</Param>
+      <Param ControlIndex="2">33024</Param>
+      <Param ControlIndex="3">65280</Param>
+      <Param ControlIndex="4">33280</Param>
+      <Param ControlIndex="5">38912</Param>
+      <Param ControlIndex="6">42496</Param>
+      <Param ControlIndex="7">13312</Param>
+      <Param ControlIndex="8">33024</Param>
+      <Param ControlIndex="9">0</Param>
+      <Param ControlIndex="10">33024</Param>
+      <Param ControlIndex="11">33024</Param>
+      <Param ControlIndex="12">4</Param>
+      <Param ControlIndex="13">17</Param>
+      <Param ControlIndex="14">17</Param>
+      <Param ControlIndex="15">1</Param>
+      <Param ControlIndex="16">2</Param>
+      <Param ControlIndex="17">10</Param>
+      <Param ControlIndex="18">17</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="271" POS="0" BypassState="0">
+        <Param ControlIndex="0">36864</Param>
+        <Param ControlIndex="1">44032</Param>
+        <Param ControlIndex="2">20736</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="1" BypassState="0"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="4" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="58" POS="4" BypassState="1">
+        <Param ControlIndex="0">13312</Param>
+        <Param ControlIndex="1">16384</Param>
+        <Param ControlIndex="2">33024</Param>
+        <Param ControlIndex="3">1792</Param>
+        <Param ControlIndex="4">45312</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Loud as Leeds" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="0" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/15_LeadCommunication.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/15_LeadCommunication.fuse
@@ -1,0 +1,83 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="249" POS="0" BypassState="1">
+      <Param ControlIndex="0">36608</Param>
+      <Param ControlIndex="1">33024</Param>
+      <Param ControlIndex="2">33024</Param>
+      <Param ControlIndex="3">33024</Param>
+      <Param ControlIndex="4">44032</Param>
+      <Param ControlIndex="5">41728</Param>
+      <Param ControlIndex="6">65280</Param>
+      <Param ControlIndex="7">33024</Param>
+      <Param ControlIndex="8">33024</Param>
+      <Param ControlIndex="9">0</Param>
+      <Param ControlIndex="10">33024</Param>
+      <Param ControlIndex="11">33024</Param>
+      <Param ControlIndex="12">4</Param>
+      <Param ControlIndex="13">15</Param>
+      <Param ControlIndex="14">15</Param>
+      <Param ControlIndex="15">1</Param>
+      <Param ControlIndex="16">2</Param>
+      <Param ControlIndex="17">1</Param>
+      <Param ControlIndex="18">15</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="259" POS="0" BypassState="1">
+        <Param ControlIndex="0">65280</Param>
+        <Param ControlIndex="1">65280</Param>
+        <Param ControlIndex="2">0</Param>
+        <Param ControlIndex="3">21760</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="244" POS="1" BypassState="0">
+        <Param ControlIndex="0">65280</Param>
+        <Param ControlIndex="1">65280</Param>
+        <Param ControlIndex="2">256</Param>
+        <Param ControlIndex="3">54784</Param>
+        <Param ControlIndex="4">0</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="4" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="11" POS="4" BypassState="1">
+        <Param ControlIndex="0">2816</Param>
+        <Param ControlIndex="1">35840</Param>
+        <Param ControlIndex="2">19200</Param>
+        <Param ControlIndex="3">65280</Param>
+        <Param ControlIndex="4">33024</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="LeadCommunication" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="3" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/16_Country Deluxe.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/16_Country Deluxe.fuse
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="83" POS="0" BypassState="1">
+      <Param ControlIndex="0">55040</Param>
+      <Param ControlIndex="1">13312</Param>
+      <Param ControlIndex="2">0</Param>
+      <Param ControlIndex="3">65280</Param>
+      <Param ControlIndex="4">37120</Param>
+      <Param ControlIndex="5">52992</Param>
+      <Param ControlIndex="6">14336</Param>
+      <Param ControlIndex="7">0</Param>
+      <Param ControlIndex="8">0</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">0</Param>
+      <Param ControlIndex="12">3</Param>
+      <Param ControlIndex="13">3</Param>
+      <Param ControlIndex="14">3</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">3</Param>
+      <Param ControlIndex="18">3</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="7" POS="0" BypassState="1">
+        <Param ControlIndex="0">9472</Param>
+        <Param ControlIndex="1">17920</Param>
+        <Param ControlIndex="2">43520</Param>
+        <Param ControlIndex="3">16384</Param>
+        <Param ControlIndex="4">23808</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="11" POS="7" BypassState="1">
+        <Param ControlIndex="0">10496</Param>
+        <Param ControlIndex="1">26112</Param>
+        <Param ControlIndex="2">15616</Param>
+        <Param ControlIndex="3">14592</Param>
+        <Param ControlIndex="4">50432</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Country Deluxe" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="5" HeelSetting="12288" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="1" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/17_The Evil Bassman.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/17_The Evil Bassman.fuse
@@ -1,0 +1,76 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="100" POS="0" BypassState="1">
+      <Param ControlIndex="0">65280</Param>
+      <Param ControlIndex="1">25344</Param>
+      <Param ControlIndex="2">33024</Param>
+      <Param ControlIndex="3">33024</Param>
+      <Param ControlIndex="4">22272</Param>
+      <Param ControlIndex="5">26368</Param>
+      <Param ControlIndex="6">44288</Param>
+      <Param ControlIndex="7">0</Param>
+      <Param ControlIndex="8">33024</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">33024</Param>
+      <Param ControlIndex="11">33024</Param>
+      <Param ControlIndex="12">2</Param>
+      <Param ControlIndex="13">2</Param>
+      <Param ControlIndex="14">2</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">2</Param>
+      <Param ControlIndex="18">2</Param>
+      <Param ControlIndex="19">0</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="273" POS="2" BypassState="1">
+        <Param ControlIndex="0">17920</Param>
+        <Param ControlIndex="1">50176</Param>
+        <Param ControlIndex="2">28416</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="36" POS="7" BypassState="1">
+        <Param ControlIndex="0">14080</Param>
+        <Param ControlIndex="1">26112</Param>
+        <Param ControlIndex="2">30976</Param>
+        <Param ControlIndex="3">20992</Param>
+        <Param ControlIndex="4">65280</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="The Evil Bassman" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="6" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/18_Brighton Rock.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/18_Brighton Rock.fuse
@@ -1,0 +1,83 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="97" POS="0" BypassState="1">
+      <Param ControlIndex="0">32256</Param>
+      <Param ControlIndex="1">43776</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">41472</Param>
+      <Param ControlIndex="4">7680</Param>
+      <Param ControlIndex="5">60928</Param>
+      <Param ControlIndex="6">33280</Param>
+      <Param ControlIndex="7">33792</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">4</Param>
+      <Param ControlIndex="13">7</Param>
+      <Param ControlIndex="14">7</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">7</Param>
+      <Param ControlIndex="18">7</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="259" POS="0" BypassState="1">
+        <Param ControlIndex="0">31488</Param>
+        <Param ControlIndex="1">63232</Param>
+        <Param ControlIndex="2">0</Param>
+        <Param ControlIndex="3">29440</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="79" POS="1" BypassState="1">
+        <Param ControlIndex="0">54272</Param>
+        <Param ControlIndex="1">0</Param>
+        <Param ControlIndex="2">65280</Param>
+        <Param ControlIndex="3">24320</Param>
+        <Param ControlIndex="4">0</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="75" POS="7" BypassState="1">
+        <Param ControlIndex="0">14336</Param>
+        <Param ControlIndex="1">32768</Param>
+        <Param ControlIndex="2">37120</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">46592</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Brighton Rock" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="6" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/19_Angry Rodent.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/19_Angry Rodent.fuse
@@ -1,0 +1,76 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="94" POS="0" BypassState="1">
+      <Param ControlIndex="0">24320</Param>
+      <Param ControlIndex="1">11264</Param>
+      <Param ControlIndex="2">33024</Param>
+      <Param ControlIndex="3">64512</Param>
+      <Param ControlIndex="4">31488</Param>
+      <Param ControlIndex="5">23552</Param>
+      <Param ControlIndex="6">50432</Param>
+      <Param ControlIndex="7">0</Param>
+      <Param ControlIndex="8">33024</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">33024</Param>
+      <Param ControlIndex="11">33024</Param>
+      <Param ControlIndex="12">4</Param>
+      <Param ControlIndex="13">9</Param>
+      <Param ControlIndex="14">9</Param>
+      <Param ControlIndex="15">4</Param>
+      <Param ControlIndex="16">5</Param>
+      <Param ControlIndex="17">6</Param>
+      <Param ControlIndex="18">9</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="273" POS="0" BypassState="1">
+        <Param ControlIndex="0">55296</Param>
+        <Param ControlIndex="1">17408</Param>
+        <Param ControlIndex="2">17920</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="36" POS="4" BypassState="1">
+        <Param ControlIndex="0">3328</Param>
+        <Param ControlIndex="1">24320</Param>
+        <Param ControlIndex="2">28672</Param>
+        <Param ControlIndex="3">33024</Param>
+        <Param ControlIndex="4">37376</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Angry Rodent" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="1" HeelSetting="16384" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/20_JohnnyMarrTremolo.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/20_JohnnyMarrTremolo.fuse
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="117" POS="0" BypassState="1">
+      <Param ControlIndex="0">49664</Param>
+      <Param ControlIndex="1">36352</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">25344</Param>
+      <Param ControlIndex="4">45824</Param>
+      <Param ControlIndex="5">47872</Param>
+      <Param ControlIndex="6">43520</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">5</Param>
+      <Param ControlIndex="13">5</Param>
+      <Param ControlIndex="14">5</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">9</Param>
+      <Param ControlIndex="18">5</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="64" POS="5" BypassState="1">
+        <Param ControlIndex="0">56064</Param>
+        <Param ControlIndex="1">44288</Param>
+        <Param ControlIndex="2">25344</Param>
+        <Param ControlIndex="3">62464</Param>
+        <Param ControlIndex="4">61696</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="43" POS="6" BypassState="1">
+        <Param ControlIndex="0">32000</Param>
+        <Param ControlIndex="1">7168</Param>
+        <Param ControlIndex="2">0</Param>
+        <Param ControlIndex="3">25344</Param>
+        <Param ControlIndex="4">32768</Param>
+        <Param ControlIndex="5">0</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="33" POS="3" BypassState="1">
+        <Param ControlIndex="0">32768</Param>
+        <Param ControlIndex="1">32768</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="JohnnyMarrTremolo" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="3" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="1" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/21_Fusion Lead.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/21_Fusion Lead.fuse
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="114" POS="0" BypassState="1">
+      <Param ControlIndex="0">43520</Param>
+      <Param ControlIndex="1">43776</Param>
+      <Param ControlIndex="2">43520</Param>
+      <Param ControlIndex="3">27136</Param>
+      <Param ControlIndex="4">35072</Param>
+      <Param ControlIndex="5">20480</Param>
+      <Param ControlIndex="6">51200</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">0</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">6</Param>
+      <Param ControlIndex="13">6</Param>
+      <Param ControlIndex="14">6</Param>
+      <Param ControlIndex="15">1</Param>
+      <Param ControlIndex="16">2</Param>
+      <Param ControlIndex="17">12</Param>
+      <Param ControlIndex="18">6</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="22" POS="6" BypassState="1">
+        <Param ControlIndex="0">7680</Param>
+        <Param ControlIndex="1">16384</Param>
+        <Param ControlIndex="2">4352</Param>
+        <Param ControlIndex="3">7680</Param>
+        <Param ControlIndex="4">33024</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="59" POS="7" BypassState="1">
+        <Param ControlIndex="0">4608</Param>
+        <Param ControlIndex="1">40704</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">33024</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Fusion Lead" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="5" HeelSetting="4096" ToeSetting="32512" PedalMode="0" BypassEffectWhenVolumeMode="1" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/22_C Baritone Clean.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/22_C Baritone Clean.fuse
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="117" POS="0" BypassState="1">
+      <Param ControlIndex="0">44032</Param>
+      <Param ControlIndex="1">22016</Param>
+      <Param ControlIndex="2">33024</Param>
+      <Param ControlIndex="3">25600</Param>
+      <Param ControlIndex="4">46080</Param>
+      <Param ControlIndex="5">48384</Param>
+      <Param ControlIndex="6">44032</Param>
+      <Param ControlIndex="7">33024</Param>
+      <Param ControlIndex="8">33024</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">33024</Param>
+      <Param ControlIndex="11">33024</Param>
+      <Param ControlIndex="12">4</Param>
+      <Param ControlIndex="13">5</Param>
+      <Param ControlIndex="14">5</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">9</Param>
+      <Param ControlIndex="18">5</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="0"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="31" POS="1" BypassState="1">
+        <Param ControlIndex="0">65280</Param>
+        <Param ControlIndex="1">27392</Param>
+        <Param ControlIndex="2">0</Param>
+        <Param ControlIndex="3">0</Param>
+        <Param ControlIndex="4">44288</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="33" POS="7" BypassState="1">
+        <Param ControlIndex="0">18944</Param>
+        <Param ControlIndex="1">37888</Param>
+        <Param ControlIndex="2">39680</Param>
+        <Param ControlIndex="3">33024</Param>
+        <Param ControlIndex="4">33024</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="C Baritone Clean" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="3" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/23_Doom Hand.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/23_Doom Hand.fuse
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="252" POS="0" BypassState="1">
+      <Param ControlIndex="0">42240</Param>
+      <Param ControlIndex="1">40704</Param>
+      <Param ControlIndex="2">33024</Param>
+      <Param ControlIndex="3">33024</Param>
+      <Param ControlIndex="4">51200</Param>
+      <Param ControlIndex="5">40448</Param>
+      <Param ControlIndex="6">39168</Param>
+      <Param ControlIndex="7">33024</Param>
+      <Param ControlIndex="8">33024</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">33024</Param>
+      <Param ControlIndex="11">33024</Param>
+      <Param ControlIndex="12">4</Param>
+      <Param ControlIndex="13">16</Param>
+      <Param ControlIndex="14">16</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">11</Param>
+      <Param ControlIndex="18">16</Param>
+      <Param ControlIndex="19">0</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="259" POS="0" BypassState="1">
+        <Param ControlIndex="0">30976</Param>
+        <Param ControlIndex="1">7680</Param>
+        <Param ControlIndex="2">0</Param>
+        <Param ControlIndex="3">56576</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="4" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="0"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="38" POS="7" BypassState="1">
+        <Param ControlIndex="0">22528</Param>
+        <Param ControlIndex="1">7680</Param>
+        <Param ControlIndex="2">28160</Param>
+        <Param ControlIndex="3">33024</Param>
+        <Param ControlIndex="4">33024</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Doom Hand" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="6" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/24_Beauty Clean.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/24_Beauty Clean.fuse
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="117" POS="0" BypassState="1">
+      <Param ControlIndex="0">39936</Param>
+      <Param ControlIndex="1">32512</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">25344</Param>
+      <Param ControlIndex="4">51712</Param>
+      <Param ControlIndex="5">41216</Param>
+      <Param ControlIndex="6">55296</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">0</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">5</Param>
+      <Param ControlIndex="13">5</Param>
+      <Param ControlIndex="14">5</Param>
+      <Param ControlIndex="15">1</Param>
+      <Param ControlIndex="16">2</Param>
+      <Param ControlIndex="17">9</Param>
+      <Param ControlIndex="18">5</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="7" POS="0" BypassState="1">
+        <Param ControlIndex="0">21504</Param>
+        <Param ControlIndex="1">3840</Param>
+        <Param ControlIndex="2">20224</Param>
+        <Param ControlIndex="3">32512</Param>
+        <Param ControlIndex="4">32512</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="43" POS="6" BypassState="1">
+        <Param ControlIndex="0">18944</Param>
+        <Param ControlIndex="1">40704</Param>
+        <Param ControlIndex="2">7168</Param>
+        <Param ControlIndex="3">39680</Param>
+        <Param ControlIndex="4">21504</Param>
+        <Param ControlIndex="5">0</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="58" POS="7" BypassState="1">
+        <Param ControlIndex="0">32768</Param>
+        <Param ControlIndex="1">32768</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">50688</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Beauty Clean" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="4" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="1" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/25_Movie Tremolux.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/25_Movie Tremolux.fuse
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="103" POS="0" BypassState="1">
+      <Param ControlIndex="0">43520</Param>
+      <Param ControlIndex="1">31488</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32768</Param>
+      <Param ControlIndex="4">48640</Param>
+      <Param ControlIndex="5">32768</Param>
+      <Param ControlIndex="6">32768</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">1</Param>
+      <Param ControlIndex="13">1</Param>
+      <Param ControlIndex="14">1</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">1</Param>
+      <Param ControlIndex="18">1</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="65" POS="5" BypassState="1">
+        <Param ControlIndex="0">49408</Param>
+        <Param ControlIndex="1">22016</Param>
+        <Param ControlIndex="2">32000</Param>
+        <Param ControlIndex="3">0</Param>
+        <Param ControlIndex="4">0</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="42" POS="6" BypassState="1">
+        <Param ControlIndex="0">15616</Param>
+        <Param ControlIndex="1">55808</Param>
+        <Param ControlIndex="2">8192</Param>
+        <Param ControlIndex="3">25344</Param>
+        <Param ControlIndex="4">65280</Param>
+        <Param ControlIndex="5">32768</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="59" POS="7" BypassState="1">
+        <Param ControlIndex="0">15104</Param>
+        <Param ControlIndex="1">32768</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Movie Tremolux" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="3" HeelSetting="0" ToeSetting="36608" PedalMode="0" BypassEffectWhenVolumeMode="1" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/26_Europa.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/26_Europa.fuse
@@ -1,0 +1,91 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="93" POS="0" BypassState="1">
+      <Param ControlIndex="0">41472</Param>
+      <Param ControlIndex="1">64768</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">26112</Param>
+      <Param ControlIndex="4">28672</Param>
+      <Param ControlIndex="5">54784</Param>
+      <Param ControlIndex="6">55040</Param>
+      <Param ControlIndex="7">27136</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">10</Param>
+      <Param ControlIndex="13">10</Param>
+      <Param ControlIndex="14">10</Param>
+      <Param ControlIndex="15">3</Param>
+      <Param ControlIndex="16">4</Param>
+      <Param ControlIndex="17">10</Param>
+      <Param ControlIndex="18">10</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="60" POS="0" BypassState="1">
+        <Param ControlIndex="0">65280</Param>
+        <Param ControlIndex="1">62720</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">40192</Param>
+        <Param ControlIndex="4">26880</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="79" POS="1" BypassState="1">
+        <Param ControlIndex="0">35328</Param>
+        <Param ControlIndex="1">0</Param>
+        <Param ControlIndex="2">41472</Param>
+        <Param ControlIndex="3">39936</Param>
+        <Param ControlIndex="4">0</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="43" POS="6" BypassState="1">
+        <Param ControlIndex="0">32000</Param>
+        <Param ControlIndex="1">25344</Param>
+        <Param ControlIndex="2">13568</Param>
+        <Param ControlIndex="3">25344</Param>
+        <Param ControlIndex="4">32768</Param>
+        <Param ControlIndex="5">0</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="58" POS="7" BypassState="1">
+        <Param ControlIndex="0">26368</Param>
+        <Param ControlIndex="1">15872</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">1280</Param>
+        <Param ControlIndex="4">45056</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Europa" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="4" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="1" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="2" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/27_Dirty Deluxe.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/27_Dirty Deluxe.fuse
@@ -1,0 +1,90 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="103" POS="0" BypassState="1">
+      <Param ControlIndex="0">43520</Param>
+      <Param ControlIndex="1">43264</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32768</Param>
+      <Param ControlIndex="4">48640</Param>
+      <Param ControlIndex="5">32768</Param>
+      <Param ControlIndex="6">32768</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">46336</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">1</Param>
+      <Param ControlIndex="13">1</Param>
+      <Param ControlIndex="14">1</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">1</Param>
+      <Param ControlIndex="18">1</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="60" POS="0" BypassState="1">
+        <Param ControlIndex="0">36608</Param>
+        <Param ControlIndex="1">32768</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="64" POS="5" BypassState="0">
+        <Param ControlIndex="0">43264</Param>
+        <Param ControlIndex="1">9472</Param>
+        <Param ControlIndex="2">25344</Param>
+        <Param ControlIndex="3">62464</Param>
+        <Param ControlIndex="4">61696</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="21" POS="6" BypassState="0">
+        <Param ControlIndex="0">25088</Param>
+        <Param ControlIndex="1">23040</Param>
+        <Param ControlIndex="2">16128</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="38" POS="7" BypassState="1">
+        <Param ControlIndex="0">32768</Param>
+        <Param ControlIndex="1">32768</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Dirty Deluxe" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="3" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="1" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/28_Aussie Rock.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/28_Aussie Rock.fuse
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="94" POS="0" BypassState="1">
+      <Param ControlIndex="0">50944</Param>
+      <Param ControlIndex="1">65280</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32000</Param>
+      <Param ControlIndex="4">36352</Param>
+      <Param ControlIndex="5">34560</Param>
+      <Param ControlIndex="6">50176</Param>
+      <Param ControlIndex="7">33024</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">0</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">9</Param>
+      <Param ControlIndex="13">9</Param>
+      <Param ControlIndex="14">9</Param>
+      <Param ControlIndex="15">1</Param>
+      <Param ControlIndex="16">2</Param>
+      <Param ControlIndex="17">6</Param>
+      <Param ControlIndex="18">9</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="36" POS="7" BypassState="1">
+        <Param ControlIndex="0">14848</Param>
+        <Param ControlIndex="1">23808</Param>
+        <Param ControlIndex="2">28160</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">37120</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Aussie Rock" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="5" HeelSetting="4096" ToeSetting="40704" PedalMode="0" BypassEffectWhenVolumeMode="1" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/29_Metal Octave.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/29_Metal Octave.fuse
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="109" POS="0" BypassState="1">
+      <Param ControlIndex="0">45824</Param>
+      <Param ControlIndex="1">32768</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">21760</Param>
+      <Param ControlIndex="4">39168</Param>
+      <Param ControlIndex="5">19456</Param>
+      <Param ControlIndex="6">37120</Param>
+      <Param ControlIndex="7">36352</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">8</Param>
+      <Param ControlIndex="13">8</Param>
+      <Param ControlIndex="14">8</Param>
+      <Param ControlIndex="15">2</Param>
+      <Param ControlIndex="16">3</Param>
+      <Param ControlIndex="17">8</Param>
+      <Param ControlIndex="18">8</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="31" POS="5" BypassState="1">
+        <Param ControlIndex="0">22016</Param>
+        <Param ControlIndex="1">16384</Param>
+        <Param ControlIndex="2">0</Param>
+        <Param ControlIndex="3">0</Param>
+        <Param ControlIndex="4">51200</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="75" POS="7" BypassState="0">
+        <Param ControlIndex="0">14336</Param>
+        <Param ControlIndex="1">32768</Param>
+        <Param ControlIndex="2">37120</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">46592</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Metal Octave" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="6" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/30_Neil Deluxe.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/30_Neil Deluxe.fuse
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="103" POS="0" BypassState="1">
+      <Param ControlIndex="0">42240</Param>
+      <Param ControlIndex="1">51456</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32768</Param>
+      <Param ControlIndex="4">43776</Param>
+      <Param ControlIndex="5">32768</Param>
+      <Param ControlIndex="6">32768</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">1</Param>
+      <Param ControlIndex="13">1</Param>
+      <Param ControlIndex="14">1</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">1</Param>
+      <Param ControlIndex="18">1</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="43" POS="6" BypassState="1">
+        <Param ControlIndex="0">13056</Param>
+        <Param ControlIndex="1">11776</Param>
+        <Param ControlIndex="2">4864</Param>
+        <Param ControlIndex="3">25344</Param>
+        <Param ControlIndex="4">32768</Param>
+        <Param ControlIndex="5">0</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="33" POS="3" BypassState="1">
+        <Param ControlIndex="0">4352</Param>
+        <Param ControlIndex="1">27904</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">47616</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Neil Deluxe" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="5" HeelSetting="4096" ToeSetting="32512" PedalMode="0" BypassEffectWhenVolumeMode="1" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/31_Touch of Reverb.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/31_Touch of Reverb.fuse
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="117" POS="0" BypassState="1">
+      <Param ControlIndex="0">49152</Param>
+      <Param ControlIndex="1">23296</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32768</Param>
+      <Param ControlIndex="4">32512</Param>
+      <Param ControlIndex="5">42496</Param>
+      <Param ControlIndex="6">43520</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">5</Param>
+      <Param ControlIndex="13">5</Param>
+      <Param ControlIndex="14">5</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">9</Param>
+      <Param ControlIndex="18">5</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="11" POS="7" BypassState="1">
+        <Param ControlIndex="0">23040</Param>
+        <Param ControlIndex="1">47616</Param>
+        <Param ControlIndex="2">40192</Param>
+        <Param ControlIndex="3">12288</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Touch of Reverb" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="5" HeelSetting="12288" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="1" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/32_Purple Fuzz.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/32_Purple Fuzz.fuse
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="121" POS="0" BypassState="1">
+      <Param ControlIndex="0">43520</Param>
+      <Param ControlIndex="1">65280</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32000</Param>
+      <Param ControlIndex="4">43520</Param>
+      <Param ControlIndex="5">23296</Param>
+      <Param ControlIndex="6">50176</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">11</Param>
+      <Param ControlIndex="13">11</Param>
+      <Param ControlIndex="14">11</Param>
+      <Param ControlIndex="15">2</Param>
+      <Param ControlIndex="16">3</Param>
+      <Param ControlIndex="17">8</Param>
+      <Param ControlIndex="18">11</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="26" POS="0" BypassState="1">
+        <Param ControlIndex="0">32768</Param>
+        <Param ControlIndex="1">44800</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">46848</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="58" POS="4" BypassState="1">
+        <Param ControlIndex="0">20224</Param>
+        <Param ControlIndex="1">15872</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">1280</Param>
+        <Param ControlIndex="4">45056</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Purple Fuzz" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="5" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="1" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/33_Amin 3rds Solo.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/33_Amin 3rds Solo.fuse
@@ -1,0 +1,87 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="106" POS="0" BypassState="1">
+      <Param ControlIndex="0">43520</Param>
+      <Param ControlIndex="1">21760</Param>
+      <Param ControlIndex="2">0</Param>
+      <Param ControlIndex="3">65280</Param>
+      <Param ControlIndex="4">39168</Param>
+      <Param ControlIndex="5">52224</Param>
+      <Param ControlIndex="6">19456</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">4</Param>
+      <Param ControlIndex="13">4</Param>
+      <Param ControlIndex="14">4</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">4</Param>
+      <Param ControlIndex="18">4</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="136" POS="0" BypassState="1">
+        <Param ControlIndex="0">1</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="4127" POS="4" BypassState="1">
+        <Param ControlIndex="0">21760</Param>
+        <Param ControlIndex="1">9</Param>
+        <Param ControlIndex="2">9</Param>
+        <Param ControlIndex="3">5</Param>
+        <Param ControlIndex="4">51200</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="72" POS="6" BypassState="1">
+        <Param ControlIndex="0">12800</Param>
+        <Param ControlIndex="1">45824</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">32768</Param>
+        <Param ControlIndex="5">32768</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="11" POS="7" BypassState="1">
+        <Param ControlIndex="0">32768</Param>
+        <Param ControlIndex="1">35584</Param>
+        <Param ControlIndex="2">18688</Param>
+        <Param ControlIndex="3">65280</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Amin 3rds Solo" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="3" HeelSetting="0" ToeSetting="26368" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/34_Bassman Drive.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/34_Bassman Drive.fuse
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="100" POS="0" BypassState="1">
+      <Param ControlIndex="0">33024</Param>
+      <Param ControlIndex="1">50432</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32768</Param>
+      <Param ControlIndex="4">40192</Param>
+      <Param ControlIndex="5">25600</Param>
+      <Param ControlIndex="6">41472</Param>
+      <Param ControlIndex="7">37120</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">2</Param>
+      <Param ControlIndex="13">2</Param>
+      <Param ControlIndex="14">2</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">2</Param>
+      <Param ControlIndex="18">2</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="38" POS="7" BypassState="1">
+        <Param ControlIndex="0">22528</Param>
+        <Param ControlIndex="1">32768</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Bassman Drive" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="5" HeelSetting="4096" ToeSetting="40704" PedalMode="0" BypassEffectWhenVolumeMode="1" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/35_Doom Orleans.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/35_Doom Orleans.fuse
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="97" POS="0" BypassState="1">
+      <Param ControlIndex="0">38144</Param>
+      <Param ControlIndex="1">42496</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">41472</Param>
+      <Param ControlIndex="4">39168</Param>
+      <Param ControlIndex="5">36608</Param>
+      <Param ControlIndex="6">29184</Param>
+      <Param ControlIndex="7">0</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">7</Param>
+      <Param ControlIndex="13">7</Param>
+      <Param ControlIndex="14">7</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">10</Param>
+      <Param ControlIndex="18">7</Param>
+      <Param ControlIndex="19">2</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="26" POS="0" BypassState="1">
+        <Param ControlIndex="0">44800</Param>
+        <Param ControlIndex="1">62720</Param>
+        <Param ControlIndex="2">8704</Param>
+        <Param ControlIndex="3">54784</Param>
+        <Param ControlIndex="4">7168</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="0" POS="7" BypassState="1"></Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Doom Orleans" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="1" HeelSetting="32768" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="1" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/36_Autumns End Scars.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/36_Autumns End Scars.fuse
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="117" POS="0" BypassState="1">
+      <Param ControlIndex="0">56576</Param>
+      <Param ControlIndex="1">22016</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">25344</Param>
+      <Param ControlIndex="4">35584</Param>
+      <Param ControlIndex="5">30208</Param>
+      <Param ControlIndex="6">17408</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">26624</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">5</Param>
+      <Param ControlIndex="13">5</Param>
+      <Param ControlIndex="14">5</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">9</Param>
+      <Param ControlIndex="18">5</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="0"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="31" POS="1" BypassState="1">
+        <Param ControlIndex="0">16384</Param>
+        <Param ControlIndex="1">32512</Param>
+        <Param ControlIndex="2">65280</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">9728</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="43" POS="6" BypassState="1">
+        <Param ControlIndex="0">41728</Param>
+        <Param ControlIndex="1">13312</Param>
+        <Param ControlIndex="2">9728</Param>
+        <Param ControlIndex="3">27392</Param>
+        <Param ControlIndex="4">32768</Param>
+        <Param ControlIndex="5">0</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="11" POS="7" BypassState="1">
+        <Param ControlIndex="0">18432</Param>
+        <Param ControlIndex="1">35584</Param>
+        <Param ControlIndex="2">18688</Param>
+        <Param ControlIndex="3">65280</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Autumns End Scars" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="3" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/37_Chimey Deluxe.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/37_Chimey Deluxe.fuse
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="103" POS="0" BypassState="1">
+      <Param ControlIndex="0">43776</Param>
+      <Param ControlIndex="1">43776</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32768</Param>
+      <Param ControlIndex="4">51456</Param>
+      <Param ControlIndex="5">33024</Param>
+      <Param ControlIndex="6">18432</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">1</Param>
+      <Param ControlIndex="13">1</Param>
+      <Param ControlIndex="14">1</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">1</Param>
+      <Param ControlIndex="18">1</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="7" POS="0" BypassState="1">
+        <Param ControlIndex="0">17920</Param>
+        <Param ControlIndex="1">29440</Param>
+        <Param ControlIndex="2">43520</Param>
+        <Param ControlIndex="3">16384</Param>
+        <Param ControlIndex="4">23808</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="58" POS="7" BypassState="1">
+        <Param ControlIndex="0">20992</Param>
+        <Param ControlIndex="1">16896</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">2048</Param>
+        <Param ControlIndex="4">45312</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Chimey Deluxe" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="5" HeelSetting="16384" ToeSetting="49152" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/38_Cranked Princeton.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/38_Cranked Princeton.fuse
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="106" POS="0" BypassState="1">
+      <Param ControlIndex="0">34560</Param>
+      <Param ControlIndex="1">65024</Param>
+      <Param ControlIndex="2">0</Param>
+      <Param ControlIndex="3">65280</Param>
+      <Param ControlIndex="4">65280</Param>
+      <Param ControlIndex="5">52224</Param>
+      <Param ControlIndex="6">41472</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">58624</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">4</Param>
+      <Param ControlIndex="13">4</Param>
+      <Param ControlIndex="14">4</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">4</Param>
+      <Param ControlIndex="18">4</Param>
+      <Param ControlIndex="19">2</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="11" POS="7" BypassState="1">
+        <Param ControlIndex="0">11264</Param>
+        <Param ControlIndex="1">19200</Param>
+        <Param ControlIndex="2">18688</Param>
+        <Param ControlIndex="3">65280</Param>
+        <Param ControlIndex="4">54016</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Cranked Princeton" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="5" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/39_Day of Sighs.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/39_Day of Sighs.fuse
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="121" POS="0" BypassState="1">
+      <Param ControlIndex="0">43520</Param>
+      <Param ControlIndex="1">65280</Param>
+      <Param ControlIndex="2">65280</Param>
+      <Param ControlIndex="3">32000</Param>
+      <Param ControlIndex="4">53504</Param>
+      <Param ControlIndex="5">45824</Param>
+      <Param ControlIndex="6">50944</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">11</Param>
+      <Param ControlIndex="13">11</Param>
+      <Param ControlIndex="14">11</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">10</Param>
+      <Param ControlIndex="18">11</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="45" POS="5" BypassState="1">
+        <Param ControlIndex="0">58624</Param>
+        <Param ControlIndex="1">18176</Param>
+        <Param ControlIndex="2">4096</Param>
+        <Param ControlIndex="3">43520</Param>
+        <Param ControlIndex="4">33280</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="0"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="0" POS="7" BypassState="1"></Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Day of Sighs" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="3" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/40_Small Champ.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/40_Small Champ.fuse
@@ -1,0 +1,91 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="124" POS="0" BypassState="1">
+      <Param ControlIndex="0">49664</Param>
+      <Param ControlIndex="1">36352</Param>
+      <Param ControlIndex="2">0</Param>
+      <Param ControlIndex="3">65280</Param>
+      <Param ControlIndex="4">32768</Param>
+      <Param ControlIndex="5">36096</Param>
+      <Param ControlIndex="6">25344</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">0</Param>
+      <Param ControlIndex="10">49152</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">12</Param>
+      <Param ControlIndex="13">12</Param>
+      <Param ControlIndex="14">12</Param>
+      <Param ControlIndex="15">1</Param>
+      <Param ControlIndex="16">2</Param>
+      <Param ControlIndex="17">5</Param>
+      <Param ControlIndex="18">12</Param>
+      <Param ControlIndex="19">2</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="60" POS="0" BypassState="0">
+        <Param ControlIndex="0">22016</Param>
+        <Param ControlIndex="1">63488</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">0</Param>
+        <Param ControlIndex="4">42496</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="45" POS="5" BypassState="0">
+        <Param ControlIndex="0">46848</Param>
+        <Param ControlIndex="1">16384</Param>
+        <Param ControlIndex="2">7424</Param>
+        <Param ControlIndex="3">44288</Param>
+        <Param ControlIndex="4">33280</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="43" POS="6" BypassState="0">
+        <Param ControlIndex="0">18944</Param>
+        <Param ControlIndex="1">40704</Param>
+        <Param ControlIndex="2">7168</Param>
+        <Param ControlIndex="3">39680</Param>
+        <Param ControlIndex="4">21504</Param>
+        <Param ControlIndex="5">0</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="38" POS="7" BypassState="1">
+        <Param ControlIndex="0">30720</Param>
+        <Param ControlIndex="1">40448</Param>
+        <Param ControlIndex="2">30464</Param>
+        <Param ControlIndex="3">32512</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Small Champ" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="1" HeelSetting="20480" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/41_D of SUM 41.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/41_D of SUM 41.fuse
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="97" POS="0" BypassState="1">
+      <Param ControlIndex="0">40704</Param>
+      <Param ControlIndex="1">38656</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">41472</Param>
+      <Param ControlIndex="4">35072</Param>
+      <Param ControlIndex="5">32768</Param>
+      <Param ControlIndex="6">45056</Param>
+      <Param ControlIndex="7">0</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">7</Param>
+      <Param ControlIndex="13">7</Param>
+      <Param ControlIndex="14">7</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">7</Param>
+      <Param ControlIndex="18">7</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="0" POS="7" BypassState="1"></Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="D of SUM 41" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="1" HeelSetting="32768" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/42_Bolero.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/42_Bolero.fuse
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="121" POS="0" BypassState="1">
+      <Param ControlIndex="0">43520</Param>
+      <Param ControlIndex="1">65280</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32000</Param>
+      <Param ControlIndex="4">43520</Param>
+      <Param ControlIndex="5">23296</Param>
+      <Param ControlIndex="6">50176</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">0</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">11</Param>
+      <Param ControlIndex="13">11</Param>
+      <Param ControlIndex="14">11</Param>
+      <Param ControlIndex="15">1</Param>
+      <Param ControlIndex="16">2</Param>
+      <Param ControlIndex="17">8</Param>
+      <Param ControlIndex="18">11</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="26" POS="0" BypassState="1">
+        <Param ControlIndex="0">34560</Param>
+        <Param ControlIndex="1">65280</Param>
+        <Param ControlIndex="2">256</Param>
+        <Param ControlIndex="3">48640</Param>
+        <Param ControlIndex="4">29696</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="42" POS="6" BypassState="1">
+        <Param ControlIndex="0">19456</Param>
+        <Param ControlIndex="1">27136</Param>
+        <Param ControlIndex="2">7424</Param>
+        <Param ControlIndex="3">25344</Param>
+        <Param ControlIndex="4">4352</Param>
+        <Param ControlIndex="5">32768</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="75" POS="7" BypassState="1">
+        <Param ControlIndex="0">14336</Param>
+        <Param ControlIndex="1">32768</Param>
+        <Param ControlIndex="2">37120</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">46592</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Bolero" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="4" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="2" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/43_Bassman Splash.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/43_Bassman Splash.fuse
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="100" POS="0" BypassState="1">
+      <Param ControlIndex="0">33024</Param>
+      <Param ControlIndex="1">41472</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32768</Param>
+      <Param ControlIndex="4">32768</Param>
+      <Param ControlIndex="5">49408</Param>
+      <Param ControlIndex="6">41472</Param>
+      <Param ControlIndex="7">65280</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">2</Param>
+      <Param ControlIndex="13">2</Param>
+      <Param ControlIndex="14">2</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">2</Param>
+      <Param ControlIndex="18">2</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="33" POS="3" BypassState="1">
+        <Param ControlIndex="0">25088</Param>
+        <Param ControlIndex="1">32768</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Bassman Splash" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="5" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/44_Mike of A.A.R. 1.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/44_Mike of A.A.R. 1.fuse
@@ -1,0 +1,68 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="94" POS="0" BypassState="1">
+      <Param ControlIndex="0">38656</Param>
+      <Param ControlIndex="1">65280</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32000</Param>
+      <Param ControlIndex="4">34816</Param>
+      <Param ControlIndex="5">24320</Param>
+      <Param ControlIndex="6">51968</Param>
+      <Param ControlIndex="7">33024</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">51712</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">9</Param>
+      <Param ControlIndex="13">9</Param>
+      <Param ControlIndex="14">9</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">6</Param>
+      <Param ControlIndex="18">9</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="136" POS="0" BypassState="1">
+        <Param ControlIndex="0">1</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="0" POS="7" BypassState="1"></Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Mike of A.A.R. 1" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="6" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/45_Far Beyond Driven.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/45_Far Beyond Driven.fuse
@@ -1,0 +1,84 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="93" POS="0" BypassState="1">
+      <Param ControlIndex="0">40448</Param>
+      <Param ControlIndex="1">41472</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">26112</Param>
+      <Param ControlIndex="4">65280</Param>
+      <Param ControlIndex="5">3072</Param>
+      <Param ControlIndex="6">65280</Param>
+      <Param ControlIndex="7">32000</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">10</Param>
+      <Param ControlIndex="13">10</Param>
+      <Param ControlIndex="14">10</Param>
+      <Param ControlIndex="15">4</Param>
+      <Param ControlIndex="16">5</Param>
+      <Param ControlIndex="17">10</Param>
+      <Param ControlIndex="18">10</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="60" POS="0" BypassState="1">
+        <Param ControlIndex="0">47360</Param>
+        <Param ControlIndex="1">32768</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="19" POS="5" BypassState="1">
+        <Param ControlIndex="0">21504</Param>
+        <Param ControlIndex="1">1024</Param>
+        <Param ControlIndex="2">9472</Param>
+        <Param ControlIndex="3">6400</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="58" POS="7" BypassState="1">
+        <Param ControlIndex="0">18176</Param>
+        <Param ControlIndex="1">15872</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">1280</Param>
+        <Param ControlIndex="4">45056</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Far Beyond Driven" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="5" HeelSetting="16384" ToeSetting="48896" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/46_Four Year Strong.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/46_Four Year Strong.fuse
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="94" POS="0" BypassState="1">
+      <Param ControlIndex="0">41216</Param>
+      <Param ControlIndex="1">50944</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32000</Param>
+      <Param ControlIndex="4">23296</Param>
+      <Param ControlIndex="5">38656</Param>
+      <Param ControlIndex="6">54528</Param>
+      <Param ControlIndex="7">40448</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">9</Param>
+      <Param ControlIndex="13">9</Param>
+      <Param ControlIndex="14">9</Param>
+      <Param ControlIndex="15">3</Param>
+      <Param ControlIndex="16">4</Param>
+      <Param ControlIndex="17">6</Param>
+      <Param ControlIndex="18">9</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="7" POS="0" BypassState="1">
+        <Param ControlIndex="0">43520</Param>
+        <Param ControlIndex="1">13056</Param>
+        <Param ControlIndex="2">38144</Param>
+        <Param ControlIndex="3">22784</Param>
+        <Param ControlIndex="4">49408</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="0" POS="7" BypassState="1"></Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Four Year Strong" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="2" HeelSetting="32768" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/47_Gomez Clean.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/47_Gomez Clean.fuse
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="117" POS="0" BypassState="1">
+      <Param ControlIndex="0">45824</Param>
+      <Param ControlIndex="1">16896</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">25344</Param>
+      <Param ControlIndex="4">29184</Param>
+      <Param ControlIndex="5">34048</Param>
+      <Param ControlIndex="6">20224</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">0</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">5</Param>
+      <Param ControlIndex="13">5</Param>
+      <Param ControlIndex="14">5</Param>
+      <Param ControlIndex="15">1</Param>
+      <Param ControlIndex="16">2</Param>
+      <Param ControlIndex="17">9</Param>
+      <Param ControlIndex="18">5</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="7" POS="0" BypassState="1">
+        <Param ControlIndex="0">21504</Param>
+        <Param ControlIndex="1">26880</Param>
+        <Param ControlIndex="2">19712</Param>
+        <Param ControlIndex="3">32512</Param>
+        <Param ControlIndex="4">32512</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="43" POS="6" BypassState="1">
+        <Param ControlIndex="0">14848</Param>
+        <Param ControlIndex="1">65280</Param>
+        <Param ControlIndex="2">12544</Param>
+        <Param ControlIndex="3">22528</Param>
+        <Param ControlIndex="4">17408</Param>
+        <Param ControlIndex="5">0</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="58" POS="7" BypassState="1">
+        <Param ControlIndex="0">21760</Param>
+        <Param ControlIndex="1">26624</Param>
+        <Param ControlIndex="2">39680</Param>
+        <Param ControlIndex="3">39680</Param>
+        <Param ControlIndex="4">1536</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Gomez Clean" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="5" HeelSetting="12288" ToeSetting="44800" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/48_Summerset Drive.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/48_Summerset Drive.fuse
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="124" POS="0" BypassState="1">
+      <Param ControlIndex="0">41216</Param>
+      <Param ControlIndex="1">24832</Param>
+      <Param ControlIndex="2">0</Param>
+      <Param ControlIndex="3">65280</Param>
+      <Param ControlIndex="4">35840</Param>
+      <Param ControlIndex="5">63232</Param>
+      <Param ControlIndex="6">20480</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">12</Param>
+      <Param ControlIndex="13">12</Param>
+      <Param ControlIndex="14">12</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">5</Param>
+      <Param ControlIndex="18">12</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="60" POS="0" BypassState="1">
+        <Param ControlIndex="0">54016</Param>
+        <Param ControlIndex="1">32768</Param>
+        <Param ControlIndex="2">22272</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="58" POS="7" BypassState="1">
+        <Param ControlIndex="0">4608</Param>
+        <Param ControlIndex="1">15872</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">1280</Param>
+        <Param ControlIndex="4">45056</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Summerset Drive" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="5" HeelSetting="4096" ToeSetting="32512" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/49_Supersonic Burn.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/49_Supersonic Burn.fuse
@@ -1,0 +1,91 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="114" POS="0" BypassState="1">
+      <Param ControlIndex="0">33792</Param>
+      <Param ControlIndex="1">47872</Param>
+      <Param ControlIndex="2">38144</Param>
+      <Param ControlIndex="3">25856</Param>
+      <Param ControlIndex="4">43520</Param>
+      <Param ControlIndex="5">43776</Param>
+      <Param ControlIndex="6">43520</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">0</Param>
+      <Param ControlIndex="10">39168</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">6</Param>
+      <Param ControlIndex="13">6</Param>
+      <Param ControlIndex="14">6</Param>
+      <Param ControlIndex="15">1</Param>
+      <Param ControlIndex="16">2</Param>
+      <Param ControlIndex="17">10</Param>
+      <Param ControlIndex="18">6</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="60" POS="0" BypassState="0">
+        <Param ControlIndex="0">20224</Param>
+        <Param ControlIndex="1">32768</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="79" POS="1" BypassState="0">
+        <Param ControlIndex="0">64768</Param>
+        <Param ControlIndex="1">0</Param>
+        <Param ControlIndex="2">64768</Param>
+        <Param ControlIndex="3">47104</Param>
+        <Param ControlIndex="4">0</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="67" POS="6" BypassState="0">
+        <Param ControlIndex="0">28416</Param>
+        <Param ControlIndex="1">29696</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">32768</Param>
+        <Param ControlIndex="5">32768</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="38" POS="7" BypassState="1">
+        <Param ControlIndex="0">28160</Param>
+        <Param ControlIndex="1">32768</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Supersonic Burn" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="5" HeelSetting="16384" ToeSetting="48896" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/50_Black Hole Vibe.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/50_Black Hole Vibe.fuse
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="100" POS="0" BypassState="1">
+      <Param ControlIndex="0">39936</Param>
+      <Param ControlIndex="1">32256</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32768</Param>
+      <Param ControlIndex="4">32768</Param>
+      <Param ControlIndex="5">31232</Param>
+      <Param ControlIndex="6">41472</Param>
+      <Param ControlIndex="7">65280</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">2</Param>
+      <Param ControlIndex="13">2</Param>
+      <Param ControlIndex="14">2</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">2</Param>
+      <Param ControlIndex="18">2</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="45" POS="5" BypassState="1">
+        <Param ControlIndex="0">62464</Param>
+        <Param ControlIndex="1">65280</Param>
+        <Param ControlIndex="2">9984</Param>
+        <Param ControlIndex="3">44032</Param>
+        <Param ControlIndex="4">33280</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="77" POS="7" BypassState="1">
+        <Param ControlIndex="0">15872</Param>
+        <Param ControlIndex="1">32768</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Black Hole Vibe" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="3" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="1" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/51_Super-Live Album.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/51_Super-Live Album.fuse
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="114" POS="0" BypassState="1">
+      <Param ControlIndex="0">32768</Param>
+      <Param ControlIndex="1">65280</Param>
+      <Param ControlIndex="2">29440</Param>
+      <Param ControlIndex="3">36352</Param>
+      <Param ControlIndex="4">45312</Param>
+      <Param ControlIndex="5">48896</Param>
+      <Param ControlIndex="6">39168</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">6</Param>
+      <Param ControlIndex="13">6</Param>
+      <Param ControlIndex="14">6</Param>
+      <Param ControlIndex="15">3</Param>
+      <Param ControlIndex="16">4</Param>
+      <Param ControlIndex="17">12</Param>
+      <Param ControlIndex="18">6</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="43" POS="6" BypassState="1">
+        <Param ControlIndex="0">16896</Param>
+        <Param ControlIndex="1">23808</Param>
+        <Param ControlIndex="2">11776</Param>
+        <Param ControlIndex="3">25088</Param>
+        <Param ControlIndex="4">28672</Param>
+        <Param ControlIndex="5">0</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="58" POS="7" BypassState="1">
+        <Param ControlIndex="0">18944</Param>
+        <Param ControlIndex="1">32768</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">51456</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Super-Live Album" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="4" HeelSetting="16384" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/52_Killer Cortez.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/52_Killer Cortez.fuse
@@ -1,0 +1,91 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="103" POS="0" BypassState="1">
+      <Param ControlIndex="0">37888</Param>
+      <Param ControlIndex="1">64256</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32768</Param>
+      <Param ControlIndex="4">65280</Param>
+      <Param ControlIndex="5">65280</Param>
+      <Param ControlIndex="6">65280</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">62976</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">1</Param>
+      <Param ControlIndex="13">1</Param>
+      <Param ControlIndex="14">1</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">1</Param>
+      <Param ControlIndex="18">1</Param>
+      <Param ControlIndex="19">2</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="60" POS="0" BypassState="0">
+        <Param ControlIndex="0">36608</Param>
+        <Param ControlIndex="1">32768</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="64" POS="5" BypassState="0">
+        <Param ControlIndex="0">43264</Param>
+        <Param ControlIndex="1">9472</Param>
+        <Param ControlIndex="2">25344</Param>
+        <Param ControlIndex="3">62464</Param>
+        <Param ControlIndex="4">61696</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="43" POS="6" BypassState="1">
+        <Param ControlIndex="0">32512</Param>
+        <Param ControlIndex="1">26624</Param>
+        <Param ControlIndex="2">14848</Param>
+        <Param ControlIndex="3">25344</Param>
+        <Param ControlIndex="4">65280</Param>
+        <Param ControlIndex="5">0</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="36" POS="7" BypassState="1">
+        <Param ControlIndex="0">28160</Param>
+        <Param ControlIndex="1">23808</Param>
+        <Param ControlIndex="2">28160</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">37120</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Killer Cortez" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="5" HeelSetting="16384" ToeSetting="48896" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/53_British Steel.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/53_British Steel.fuse
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="94" POS="0" BypassState="1">
+      <Param ControlIndex="0">32512</Param>
+      <Param ControlIndex="1">50944</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">48128</Param>
+      <Param ControlIndex="4">52992</Param>
+      <Param ControlIndex="5">52224</Param>
+      <Param ControlIndex="6">65280</Param>
+      <Param ControlIndex="7">36096</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">9</Param>
+      <Param ControlIndex="13">9</Param>
+      <Param ControlIndex="14">9</Param>
+      <Param ControlIndex="15">2</Param>
+      <Param ControlIndex="16">3</Param>
+      <Param ControlIndex="17">6</Param>
+      <Param ControlIndex="18">9</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="60" POS="0" BypassState="1">
+        <Param ControlIndex="0">65280</Param>
+        <Param ControlIndex="1">41472</Param>
+        <Param ControlIndex="2">39936</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">44288</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="75" POS="7" BypassState="1">
+        <Param ControlIndex="0">19456</Param>
+        <Param ControlIndex="1">32768</Param>
+        <Param ControlIndex="2">37120</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">46592</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="British Steel" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="5" HeelSetting="4096" ToeSetting="32512" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/54_Mick The Hoople.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/54_Mick The Hoople.fuse
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="121" POS="0" BypassState="1">
+      <Param ControlIndex="0">28672</Param>
+      <Param ControlIndex="1">24064</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32000</Param>
+      <Param ControlIndex="4">44032</Param>
+      <Param ControlIndex="5">44800</Param>
+      <Param ControlIndex="6">50432</Param>
+      <Param ControlIndex="7">39936</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">0</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">11</Param>
+      <Param ControlIndex="13">11</Param>
+      <Param ControlIndex="14">11</Param>
+      <Param ControlIndex="15">1</Param>
+      <Param ControlIndex="16">2</Param>
+      <Param ControlIndex="17">10</Param>
+      <Param ControlIndex="18">11</Param>
+      <Param ControlIndex="19">0</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="26" POS="0" BypassState="1">
+        <Param ControlIndex="0">64256</Param>
+        <Param ControlIndex="1">13568</Param>
+        <Param ControlIndex="2">23808</Param>
+        <Param ControlIndex="3">40704</Param>
+        <Param ControlIndex="4">28416</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="43" POS="6" BypassState="1">
+        <Param ControlIndex="0">11264</Param>
+        <Param ControlIndex="1">23296</Param>
+        <Param ControlIndex="2">0</Param>
+        <Param ControlIndex="3">25088</Param>
+        <Param ControlIndex="4">26880</Param>
+        <Param ControlIndex="5">0</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="0" POS="7" BypassState="1"></Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Mick The Hoople" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="2" HeelSetting="12288" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/55_MSG Lead.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/55_MSG Lead.fuse
@@ -1,0 +1,91 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="93" POS="0" BypassState="1">
+      <Param ControlIndex="0">43520</Param>
+      <Param ControlIndex="1">49664</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">26112</Param>
+      <Param ControlIndex="4">45056</Param>
+      <Param ControlIndex="5">23040</Param>
+      <Param ControlIndex="6">51456</Param>
+      <Param ControlIndex="7">35840</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">10</Param>
+      <Param ControlIndex="13">10</Param>
+      <Param ControlIndex="14">10</Param>
+      <Param ControlIndex="15">3</Param>
+      <Param ControlIndex="16">4</Param>
+      <Param ControlIndex="17">10</Param>
+      <Param ControlIndex="18">10</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="73" POS="0" BypassState="1">
+        <Param ControlIndex="0">33024</Param>
+        <Param ControlIndex="1">22016</Param>
+        <Param ControlIndex="2">0</Param>
+        <Param ControlIndex="3">38400</Param>
+        <Param ControlIndex="4">0</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="18" POS="5" BypassState="0">
+        <Param ControlIndex="0">65280</Param>
+        <Param ControlIndex="1">3584</Param>
+        <Param ControlIndex="2">6400</Param>
+        <Param ControlIndex="3">6400</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="43" POS="6" BypassState="1">
+        <Param ControlIndex="0">15616</Param>
+        <Param ControlIndex="1">24064</Param>
+        <Param ControlIndex="2">9728</Param>
+        <Param ControlIndex="3">31488</Param>
+        <Param ControlIndex="4">23808</Param>
+        <Param ControlIndex="5">0</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="58" POS="7" BypassState="1">
+        <Param ControlIndex="0">6656</Param>
+        <Param ControlIndex="1">15872</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">1280</Param>
+        <Param ControlIndex="4">45056</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="MSG Lead" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="2" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/56_The Cab Charles 2.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/56_The Cab Charles 2.fuse
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="83" POS="0" BypassState="1">
+      <Param ControlIndex="0">40960</Param>
+      <Param ControlIndex="1">28928</Param>
+      <Param ControlIndex="2">0</Param>
+      <Param ControlIndex="3">65280</Param>
+      <Param ControlIndex="4">37120</Param>
+      <Param ControlIndex="5">52992</Param>
+      <Param ControlIndex="6">14336</Param>
+      <Param ControlIndex="7">0</Param>
+      <Param ControlIndex="8">0</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">0</Param>
+      <Param ControlIndex="12">3</Param>
+      <Param ControlIndex="13">3</Param>
+      <Param ControlIndex="14">3</Param>
+      <Param ControlIndex="15">4</Param>
+      <Param ControlIndex="16">5</Param>
+      <Param ControlIndex="17">3</Param>
+      <Param ControlIndex="18">3</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="136" POS="0" BypassState="1">
+        <Param ControlIndex="0">1</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="22" POS="6" BypassState="1">
+        <Param ControlIndex="0">65280</Param>
+        <Param ControlIndex="1">7424</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="0" POS="7" BypassState="1"></Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="The Cab Charles 2" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="4" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/57_Alkaline Trio.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/57_Alkaline Trio.fuse
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="114" POS="0" BypassState="1">
+      <Param ControlIndex="0">37632</Param>
+      <Param ControlIndex="1">24320</Param>
+      <Param ControlIndex="2">11264</Param>
+      <Param ControlIndex="3">22784</Param>
+      <Param ControlIndex="4">35328</Param>
+      <Param ControlIndex="5">38144</Param>
+      <Param ControlIndex="6">36352</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">35072</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">6</Param>
+      <Param ControlIndex="13">6</Param>
+      <Param ControlIndex="14">6</Param>
+      <Param ControlIndex="15">4</Param>
+      <Param ControlIndex="16">5</Param>
+      <Param ControlIndex="17">10</Param>
+      <Param ControlIndex="18">6</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="22" POS="6" BypassState="1">
+        <Param ControlIndex="0">7680</Param>
+        <Param ControlIndex="1">16384</Param>
+        <Param ControlIndex="2">4352</Param>
+        <Param ControlIndex="3">7680</Param>
+        <Param ControlIndex="4">33024</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="59" POS="7" BypassState="1">
+        <Param ControlIndex="0">0</Param>
+        <Param ControlIndex="1">40704</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">33024</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Alkaline Trio" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="5" HeelSetting="0" ToeSetting="32512" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/58_One Bourbon.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/58_One Bourbon.fuse
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="103" POS="0" BypassState="1">
+      <Param ControlIndex="0">40960</Param>
+      <Param ControlIndex="1">52992</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32768</Param>
+      <Param ControlIndex="4">51456</Param>
+      <Param ControlIndex="5">28416</Param>
+      <Param ControlIndex="6">32768</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">1</Param>
+      <Param ControlIndex="13">1</Param>
+      <Param ControlIndex="14">1</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">1</Param>
+      <Param ControlIndex="18">1</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="33" POS="3" BypassState="1">
+        <Param ControlIndex="0">2048</Param>
+        <Param ControlIndex="1">27904</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">47616</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="One Bourbon" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="5" HeelSetting="1280" ToeSetting="16384" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/59_Pasadena's Phaser.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/59_Pasadena's Phaser.fuse
@@ -1,0 +1,84 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="109" POS="0" BypassState="1">
+      <Param ControlIndex="0">44288</Param>
+      <Param ControlIndex="1">35840</Param>
+      <Param ControlIndex="2">33024</Param>
+      <Param ControlIndex="3">23552</Param>
+      <Param ControlIndex="4">52736</Param>
+      <Param ControlIndex="5">21760</Param>
+      <Param ControlIndex="6">37120</Param>
+      <Param ControlIndex="7">46336</Param>
+      <Param ControlIndex="8">33024</Param>
+      <Param ControlIndex="9">0</Param>
+      <Param ControlIndex="10">33024</Param>
+      <Param ControlIndex="11">33024</Param>
+      <Param ControlIndex="12">8</Param>
+      <Param ControlIndex="13">8</Param>
+      <Param ControlIndex="14">8</Param>
+      <Param ControlIndex="15">1</Param>
+      <Param ControlIndex="16">2</Param>
+      <Param ControlIndex="17">6</Param>
+      <Param ControlIndex="18">8</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="60" POS="0" BypassState="0">
+        <Param ControlIndex="0">65280</Param>
+        <Param ControlIndex="1">0</Param>
+        <Param ControlIndex="2">38400</Param>
+        <Param ControlIndex="3">9984</Param>
+        <Param ControlIndex="4">43008</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="79" POS="1" BypassState="1">
+        <Param ControlIndex="0">27136</Param>
+        <Param ControlIndex="1">1792</Param>
+        <Param ControlIndex="2">35840</Param>
+        <Param ControlIndex="3">30976</Param>
+        <Param ControlIndex="4">0</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="75" POS="7" BypassState="1">
+        <Param ControlIndex="0">10752</Param>
+        <Param ControlIndex="1">36096</Param>
+        <Param ControlIndex="2">32512</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">41216</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Pasadena's Phaser" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="3" HeelSetting="28672" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/60_Puppet Master.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/60_Puppet Master.fuse
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="93" POS="0" BypassState="1">
+      <Param ControlIndex="0">43520</Param>
+      <Param ControlIndex="1">36352</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">26112</Param>
+      <Param ControlIndex="4">65280</Param>
+      <Param ControlIndex="5">0</Param>
+      <Param ControlIndex="6">65280</Param>
+      <Param ControlIndex="7">28928</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">10</Param>
+      <Param ControlIndex="13">10</Param>
+      <Param ControlIndex="14">10</Param>
+      <Param ControlIndex="15">3</Param>
+      <Param ControlIndex="16">4</Param>
+      <Param ControlIndex="17">10</Param>
+      <Param ControlIndex="18">10</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="0"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="0"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="58" POS="7" BypassState="1">
+        <Param ControlIndex="0">5632</Param>
+        <Param ControlIndex="1">15872</Param>
+        <Param ControlIndex="2">27392</Param>
+        <Param ControlIndex="3">1280</Param>
+        <Param ControlIndex="4">45056</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Puppet Master" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="1" HeelSetting="32768" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/61_Sic Clean.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/61_Sic Clean.fuse
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="117" POS="0" BypassState="1">
+      <Param ControlIndex="0">53504</Param>
+      <Param ControlIndex="1">24832</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">25344</Param>
+      <Param ControlIndex="4">29184</Param>
+      <Param ControlIndex="5">34048</Param>
+      <Param ControlIndex="6">20224</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">0</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">5</Param>
+      <Param ControlIndex="13">5</Param>
+      <Param ControlIndex="14">5</Param>
+      <Param ControlIndex="15">1</Param>
+      <Param ControlIndex="16">2</Param>
+      <Param ControlIndex="17">9</Param>
+      <Param ControlIndex="18">5</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="7" POS="0" BypassState="1">
+        <Param ControlIndex="0">21504</Param>
+        <Param ControlIndex="1">3840</Param>
+        <Param ControlIndex="2">20224</Param>
+        <Param ControlIndex="3">32512</Param>
+        <Param ControlIndex="4">32512</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="43" POS="6" BypassState="1">
+        <Param ControlIndex="0">18944</Param>
+        <Param ControlIndex="1">13568</Param>
+        <Param ControlIndex="2">7168</Param>
+        <Param ControlIndex="3">39680</Param>
+        <Param ControlIndex="4">21504</Param>
+        <Param ControlIndex="5">0</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="58" POS="7" BypassState="1">
+        <Param ControlIndex="0">29440</Param>
+        <Param ControlIndex="1">32768</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">50688</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Sic Clean" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="4" HeelSetting="16384" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/62_Balls to the Wall.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/62_Balls to the Wall.fuse
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="94" POS="0" BypassState="1">
+      <Param ControlIndex="0">45568</Param>
+      <Param ControlIndex="1">65280</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">35840</Param>
+      <Param ControlIndex="4">60928</Param>
+      <Param ControlIndex="5">46592</Param>
+      <Param ControlIndex="6">59904</Param>
+      <Param ControlIndex="7">38144</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">0</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">9</Param>
+      <Param ControlIndex="13">9</Param>
+      <Param ControlIndex="14">9</Param>
+      <Param ControlIndex="15">1</Param>
+      <Param ControlIndex="16">2</Param>
+      <Param ControlIndex="17">6</Param>
+      <Param ControlIndex="18">9</Param>
+      <Param ControlIndex="19">2</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="0"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="75" POS="7" BypassState="1">
+        <Param ControlIndex="0">14336</Param>
+        <Param ControlIndex="1">32768</Param>
+        <Param ControlIndex="2">37120</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">46592</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Balls to the Wall" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="5" HeelSetting="8192" ToeSetting="32512" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/63_Sic Delay Comp.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/63_Sic Delay Comp.fuse
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="109" POS="0" BypassState="1">
+      <Param ControlIndex="0">44032</Param>
+      <Param ControlIndex="1">33792</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">21760</Param>
+      <Param ControlIndex="4">15360</Param>
+      <Param ControlIndex="5">61952</Param>
+      <Param ControlIndex="6">50944</Param>
+      <Param ControlIndex="7">51968</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">0</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">8</Param>
+      <Param ControlIndex="13">8</Param>
+      <Param ControlIndex="14">8</Param>
+      <Param ControlIndex="15">1</Param>
+      <Param ControlIndex="16">2</Param>
+      <Param ControlIndex="17">8</Param>
+      <Param ControlIndex="18">8</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="7" POS="0" BypassState="1">
+        <Param ControlIndex="0">36096</Param>
+        <Param ControlIndex="1">3840</Param>
+        <Param ControlIndex="2">20224</Param>
+        <Param ControlIndex="3">32512</Param>
+        <Param ControlIndex="4">32512</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="42" POS="6" BypassState="1">
+        <Param ControlIndex="0">32000</Param>
+        <Param ControlIndex="1">22272</Param>
+        <Param ControlIndex="2">7168</Param>
+        <Param ControlIndex="3">20480</Param>
+        <Param ControlIndex="4">41216</Param>
+        <Param ControlIndex="5">32768</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="58" POS="7" BypassState="0">
+        <Param ControlIndex="0">43776</Param>
+        <Param ControlIndex="1">15872</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">1280</Param>
+        <Param ControlIndex="4">45056</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Sic Delay Comp" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="4" HeelSetting="12288" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/64_Rockabilly Train.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/64_Rockabilly Train.fuse
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="103" POS="0" BypassState="1">
+      <Param ControlIndex="0">49664</Param>
+      <Param ControlIndex="1">33792</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32768</Param>
+      <Param ControlIndex="4">48640</Param>
+      <Param ControlIndex="5">32768</Param>
+      <Param ControlIndex="6">32768</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">1</Param>
+      <Param ControlIndex="13">1</Param>
+      <Param ControlIndex="14">1</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">1</Param>
+      <Param ControlIndex="18">1</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="43" POS="6" BypassState="1">
+        <Param ControlIndex="0">33280</Param>
+        <Param ControlIndex="1">5888</Param>
+        <Param ControlIndex="2">4096</Param>
+        <Param ControlIndex="3">25344</Param>
+        <Param ControlIndex="4">32768</Param>
+        <Param ControlIndex="5">0</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="38" POS="7" BypassState="1">
+        <Param ControlIndex="0">13568</Param>
+        <Param ControlIndex="1">32768</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Rockabilly Train" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="4" HeelSetting="8192" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/65_Cheap Deluxe.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/65_Cheap Deluxe.fuse
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="83" POS="0" BypassState="1">
+      <Param ControlIndex="0">30976</Param>
+      <Param ControlIndex="1">44288</Param>
+      <Param ControlIndex="2">0</Param>
+      <Param ControlIndex="3">65280</Param>
+      <Param ControlIndex="4">37376</Param>
+      <Param ControlIndex="5">52992</Param>
+      <Param ControlIndex="6">16640</Param>
+      <Param ControlIndex="7">0</Param>
+      <Param ControlIndex="8">0</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">0</Param>
+      <Param ControlIndex="12">3</Param>
+      <Param ControlIndex="13">3</Param>
+      <Param ControlIndex="14">3</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">7</Param>
+      <Param ControlIndex="18">3</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="11" POS="7" BypassState="1">
+        <Param ControlIndex="0">5632</Param>
+        <Param ControlIndex="1">14080</Param>
+        <Param ControlIndex="2">18688</Param>
+        <Param ControlIndex="3">65280</Param>
+        <Param ControlIndex="4">28416</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Cheap Deluxe" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="5" HeelSetting="0" ToeSetting="32512" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/66_Sensitive.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/66_Sensitive.fuse
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="83" POS="0" BypassState="1">
+      <Param ControlIndex="0">41728</Param>
+      <Param ControlIndex="1">24832</Param>
+      <Param ControlIndex="2">0</Param>
+      <Param ControlIndex="3">65280</Param>
+      <Param ControlIndex="4">35072</Param>
+      <Param ControlIndex="5">52992</Param>
+      <Param ControlIndex="6">16640</Param>
+      <Param ControlIndex="7">0</Param>
+      <Param ControlIndex="8">0</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">0</Param>
+      <Param ControlIndex="12">3</Param>
+      <Param ControlIndex="13">3</Param>
+      <Param ControlIndex="14">3</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">3</Param>
+      <Param ControlIndex="18">3</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="60" POS="0" BypassState="1">
+        <Param ControlIndex="0">22784</Param>
+        <Param ControlIndex="1">40192</Param>
+        <Param ControlIndex="2">37632</Param>
+        <Param ControlIndex="3">29184</Param>
+        <Param ControlIndex="4">30720</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="42" POS="6" BypassState="1">
+        <Param ControlIndex="0">16640</Param>
+        <Param ControlIndex="1">35072</Param>
+        <Param ControlIndex="2">7168</Param>
+        <Param ControlIndex="3">25344</Param>
+        <Param ControlIndex="4">65280</Param>
+        <Param ControlIndex="5">32768</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="11" POS="7" BypassState="1">
+        <Param ControlIndex="0">7168</Param>
+        <Param ControlIndex="1">35584</Param>
+        <Param ControlIndex="2">18688</Param>
+        <Param ControlIndex="3">65280</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Sensitive" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="1" HeelSetting="20480" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/67_South of Heaven.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/67_South of Heaven.fuse
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="94" POS="0" BypassState="1">
+      <Param ControlIndex="0">43520</Param>
+      <Param ControlIndex="1">65280</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32000</Param>
+      <Param ControlIndex="4">57344</Param>
+      <Param ControlIndex="5">43776</Param>
+      <Param ControlIndex="6">65280</Param>
+      <Param ControlIndex="7">38912</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">9</Param>
+      <Param ControlIndex="13">9</Param>
+      <Param ControlIndex="14">9</Param>
+      <Param ControlIndex="15">3</Param>
+      <Param ControlIndex="16">4</Param>
+      <Param ControlIndex="17">6</Param>
+      <Param ControlIndex="18">9</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="60" POS="0" BypassState="1">
+        <Param ControlIndex="0">56832</Param>
+        <Param ControlIndex="1">53504</Param>
+        <Param ControlIndex="2">43264</Param>
+        <Param ControlIndex="3">63232</Param>
+        <Param ControlIndex="4">28416</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="58" POS="7" BypassState="1">
+        <Param ControlIndex="0">16640</Param>
+        <Param ControlIndex="1">15872</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">1280</Param>
+        <Param ControlIndex="4">45056</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="South of Heaven" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="5" HeelSetting="4096" ToeSetting="32512" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/68_Twisted Lead.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/68_Twisted Lead.fuse
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="94" POS="0" BypassState="1">
+      <Param ControlIndex="0">50944</Param>
+      <Param ControlIndex="1">65280</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32000</Param>
+      <Param ControlIndex="4">36352</Param>
+      <Param ControlIndex="5">34560</Param>
+      <Param ControlIndex="6">50176</Param>
+      <Param ControlIndex="7">33024</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">0</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">9</Param>
+      <Param ControlIndex="13">9</Param>
+      <Param ControlIndex="14">9</Param>
+      <Param ControlIndex="15">1</Param>
+      <Param ControlIndex="16">2</Param>
+      <Param ControlIndex="17">6</Param>
+      <Param ControlIndex="18">9</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="60" POS="0" BypassState="1">
+        <Param ControlIndex="0">33280</Param>
+        <Param ControlIndex="1">60160</Param>
+        <Param ControlIndex="2">48640</Param>
+        <Param ControlIndex="3">43776</Param>
+        <Param ControlIndex="4">26880</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="72" POS="6" BypassState="1">
+        <Param ControlIndex="0">9984</Param>
+        <Param ControlIndex="1">62976</Param>
+        <Param ControlIndex="2">27904</Param>
+        <Param ControlIndex="3">32000</Param>
+        <Param ControlIndex="4">41216</Param>
+        <Param ControlIndex="5">32768</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="36" POS="7" BypassState="1">
+        <Param ControlIndex="0">18944</Param>
+        <Param ControlIndex="1">29440</Param>
+        <Param ControlIndex="2">28160</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">37120</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Twisted Lead" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="4" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="1" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="2" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/69_SetYourGoals Gaia.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/69_SetYourGoals Gaia.fuse
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="94" POS="0" BypassState="1">
+      <Param ControlIndex="0">50944</Param>
+      <Param ControlIndex="1">65280</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32000</Param>
+      <Param ControlIndex="4">36352</Param>
+      <Param ControlIndex="5">34560</Param>
+      <Param ControlIndex="6">50176</Param>
+      <Param ControlIndex="7">33024</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">0</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">9</Param>
+      <Param ControlIndex="13">9</Param>
+      <Param ControlIndex="14">9</Param>
+      <Param ControlIndex="15">1</Param>
+      <Param ControlIndex="16">2</Param>
+      <Param ControlIndex="17">6</Param>
+      <Param ControlIndex="18">9</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="60" POS="0" BypassState="1">
+        <Param ControlIndex="0">24576</Param>
+        <Param ControlIndex="1">36864</Param>
+        <Param ControlIndex="2">47616</Param>
+        <Param ControlIndex="3">39680</Param>
+        <Param ControlIndex="4">29696</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="0"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="36" POS="7" BypassState="1">
+        <Param ControlIndex="0">21760</Param>
+        <Param ControlIndex="1">29440</Param>
+        <Param ControlIndex="2">27392</Param>
+        <Param ControlIndex="3">33792</Param>
+        <Param ControlIndex="4">38144</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="SetYourGoals Gaia" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="2" HeelSetting="20480" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/70_This Love.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/70_This Love.fuse
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="117" POS="0" BypassState="1">
+      <Param ControlIndex="0">58368</Param>
+      <Param ControlIndex="1">16128</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">25344</Param>
+      <Param ControlIndex="4">47872</Param>
+      <Param ControlIndex="5">23040</Param>
+      <Param ControlIndex="6">64256</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">5</Param>
+      <Param ControlIndex="13">5</Param>
+      <Param ControlIndex="14">5</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">10</Param>
+      <Param ControlIndex="18">5</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="18" POS="5" BypassState="1">
+        <Param ControlIndex="0">65280</Param>
+        <Param ControlIndex="1">4864</Param>
+        <Param ControlIndex="2">9984</Param>
+        <Param ControlIndex="3">9728</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="43" POS="6" BypassState="1">
+        <Param ControlIndex="0">15616</Param>
+        <Param ControlIndex="1">24832</Param>
+        <Param ControlIndex="2">12800</Param>
+        <Param ControlIndex="3">25600</Param>
+        <Param ControlIndex="4">22272</Param>
+        <Param ControlIndex="5">0</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="58" POS="7" BypassState="1">
+        <Param ControlIndex="0">31488</Param>
+        <Param ControlIndex="1">30976</Param>
+        <Param ControlIndex="2">38400</Param>
+        <Param ControlIndex="3">3840</Param>
+        <Param ControlIndex="4">17408</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="This Love" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="4" HeelSetting="12288" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/71_What the Fuzz!.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/71_What the Fuzz!.fuse
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="94" POS="0" BypassState="1">
+      <Param ControlIndex="0">47616</Param>
+      <Param ControlIndex="1">65280</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32000</Param>
+      <Param ControlIndex="4">43520</Param>
+      <Param ControlIndex="5">23296</Param>
+      <Param ControlIndex="6">50176</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">0</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">4</Param>
+      <Param ControlIndex="13">9</Param>
+      <Param ControlIndex="14">9</Param>
+      <Param ControlIndex="15">1</Param>
+      <Param ControlIndex="16">2</Param>
+      <Param ControlIndex="17">6</Param>
+      <Param ControlIndex="18">9</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="26" POS="0" BypassState="1">
+        <Param ControlIndex="0">18432</Param>
+        <Param ControlIndex="1">65280</Param>
+        <Param ControlIndex="2">44032</Param>
+        <Param ControlIndex="3">40192</Param>
+        <Param ControlIndex="4">11264</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="41" POS="5" BypassState="1">
+        <Param ControlIndex="0">65280</Param>
+        <Param ControlIndex="1">32768</Param>
+        <Param ControlIndex="2">61184</Param>
+        <Param ControlIndex="3">33024</Param>
+        <Param ControlIndex="4">48128</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="72" POS="6" BypassState="1">
+        <Param ControlIndex="0">32768</Param>
+        <Param ControlIndex="1">45824</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">32768</Param>
+        <Param ControlIndex="5">32768</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="0" POS="7" BypassState="1"></Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="What the Fuzz!" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="6" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="1" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/72_Wylde '80s Lead.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/72_Wylde '80s Lead.fuse
@@ -1,0 +1,91 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="94" POS="0" BypassState="1">
+      <Param ControlIndex="0">43520</Param>
+      <Param ControlIndex="1">65280</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32000</Param>
+      <Param ControlIndex="4">64512</Param>
+      <Param ControlIndex="5">39424</Param>
+      <Param ControlIndex="6">59904</Param>
+      <Param ControlIndex="7">39936</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">9</Param>
+      <Param ControlIndex="13">9</Param>
+      <Param ControlIndex="14">9</Param>
+      <Param ControlIndex="15">3</Param>
+      <Param ControlIndex="16">4</Param>
+      <Param ControlIndex="17">6</Param>
+      <Param ControlIndex="18">9</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="60" POS="0" BypassState="1">
+        <Param ControlIndex="0">54272</Param>
+        <Param ControlIndex="1">52224</Param>
+        <Param ControlIndex="2">50432</Param>
+        <Param ControlIndex="3">47872</Param>
+        <Param ControlIndex="4">45056</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="18" POS="5" BypassState="1">
+        <Param ControlIndex="0">32256</Param>
+        <Param ControlIndex="1">8448</Param>
+        <Param ControlIndex="2">6400</Param>
+        <Param ControlIndex="3">6400</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="43" POS="6" BypassState="1">
+        <Param ControlIndex="0">28928</Param>
+        <Param ControlIndex="1">28160</Param>
+        <Param ControlIndex="2">4864</Param>
+        <Param ControlIndex="3">27904</Param>
+        <Param ControlIndex="4">16128</Param>
+        <Param ControlIndex="5">0</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="58" POS="7" BypassState="1">
+        <Param ControlIndex="0">33024</Param>
+        <Param ControlIndex="1">15872</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">1280</Param>
+        <Param ControlIndex="4">45056</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Wylde '80s Lead" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="4" HeelSetting="24576" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/73_Down Laid.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/73_Down Laid.fuse
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="93" POS="0" BypassState="1">
+      <Param ControlIndex="0">40192</Param>
+      <Param ControlIndex="1">36352</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">26112</Param>
+      <Param ControlIndex="4">41984</Param>
+      <Param ControlIndex="5">6400</Param>
+      <Param ControlIndex="6">50944</Param>
+      <Param ControlIndex="7">28928</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">0</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">10</Param>
+      <Param ControlIndex="13">10</Param>
+      <Param ControlIndex="14">10</Param>
+      <Param ControlIndex="15">1</Param>
+      <Param ControlIndex="16">2</Param>
+      <Param ControlIndex="17">6</Param>
+      <Param ControlIndex="18">10</Param>
+      <Param ControlIndex="19">0</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="43" POS="6" BypassState="1">
+        <Param ControlIndex="0">15360</Param>
+        <Param ControlIndex="1">28416</Param>
+        <Param ControlIndex="2">11264</Param>
+        <Param ControlIndex="3">25344</Param>
+        <Param ControlIndex="4">32768</Param>
+        <Param ControlIndex="5">0</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="59" POS="7" BypassState="1">
+        <Param ControlIndex="0">12800</Param>
+        <Param ControlIndex="1">32768</Param>
+        <Param ControlIndex="2">32768</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Down Laid" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="5" HeelSetting="0" ToeSetting="32512" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/74_Juicy Clean.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/74_Juicy Clean.fuse
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="83" POS="0" BypassState="1">
+      <Param ControlIndex="0">37888</Param>
+      <Param ControlIndex="1">33792</Param>
+      <Param ControlIndex="2">0</Param>
+      <Param ControlIndex="3">65280</Param>
+      <Param ControlIndex="4">30720</Param>
+      <Param ControlIndex="5">30464</Param>
+      <Param ControlIndex="6">17664</Param>
+      <Param ControlIndex="7">0</Param>
+      <Param ControlIndex="8">0</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">46080</Param>
+      <Param ControlIndex="11">0</Param>
+      <Param ControlIndex="12">3</Param>
+      <Param ControlIndex="13">3</Param>
+      <Param ControlIndex="14">3</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">0</Param>
+      <Param ControlIndex="18">3</Param>
+      <Param ControlIndex="19">0</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="43" POS="6" BypassState="1">
+        <Param ControlIndex="0">7168</Param>
+        <Param ControlIndex="1">29696</Param>
+        <Param ControlIndex="2">15872</Param>
+        <Param ControlIndex="3">0</Param>
+        <Param ControlIndex="4">12800</Param>
+        <Param ControlIndex="5">0</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="11" POS="7" BypassState="1">
+        <Param ControlIndex="0">13056</Param>
+        <Param ControlIndex="1">33792</Param>
+        <Param ControlIndex="2">19712</Param>
+        <Param ControlIndex="3">61440</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Juicy Clean" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="4" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/75_Swirlin Diddy.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/75_Swirlin Diddy.fuse
@@ -1,0 +1,91 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="106" POS="0" BypassState="1">
+      <Param ControlIndex="0">43776</Param>
+      <Param ControlIndex="1">28672</Param>
+      <Param ControlIndex="2">0</Param>
+      <Param ControlIndex="3">65280</Param>
+      <Param ControlIndex="4">37888</Param>
+      <Param ControlIndex="5">39424</Param>
+      <Param ControlIndex="6">17152</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">12032</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">4</Param>
+      <Param ControlIndex="13">4</Param>
+      <Param ControlIndex="14">4</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">4</Param>
+      <Param ControlIndex="18">4</Param>
+      <Param ControlIndex="19">0</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="7" POS="0" BypassState="1">
+        <Param ControlIndex="0">32512</Param>
+        <Param ControlIndex="1">7424</Param>
+        <Param ControlIndex="2">8448</Param>
+        <Param ControlIndex="3">0</Param>
+        <Param ControlIndex="4">32512</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="45" POS="5" BypassState="1">
+        <Param ControlIndex="0">48896</Param>
+        <Param ControlIndex="1">48384</Param>
+        <Param ControlIndex="2">16896</Param>
+        <Param ControlIndex="3">16640</Param>
+        <Param ControlIndex="4">24064</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="43" POS="6" BypassState="1">
+        <Param ControlIndex="0">7168</Param>
+        <Param ControlIndex="1">29696</Param>
+        <Param ControlIndex="2">15872</Param>
+        <Param ControlIndex="3">0</Param>
+        <Param ControlIndex="4">12800</Param>
+        <Param ControlIndex="5">0</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="11" POS="7" BypassState="1">
+        <Param ControlIndex="0">13056</Param>
+        <Param ControlIndex="1">33792</Param>
+        <Param ControlIndex="2">19712</Param>
+        <Param ControlIndex="3">61440</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Swirlin Diddy" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="3" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/76_Live N Dangerous.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/76_Live N Dangerous.fuse
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="121" POS="0" BypassState="1">
+      <Param ControlIndex="0">43264</Param>
+      <Param ControlIndex="1">47616</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32000</Param>
+      <Param ControlIndex="4">40960</Param>
+      <Param ControlIndex="5">53248</Param>
+      <Param ControlIndex="6">46592</Param>
+      <Param ControlIndex="7">39168</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">11</Param>
+      <Param ControlIndex="13">11</Param>
+      <Param ControlIndex="14">11</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">10</Param>
+      <Param ControlIndex="18">11</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="43" POS="6" BypassState="1">
+        <Param ControlIndex="0">16640</Param>
+        <Param ControlIndex="1">18944</Param>
+        <Param ControlIndex="2">4608</Param>
+        <Param ControlIndex="3">25344</Param>
+        <Param ControlIndex="4">32768</Param>
+        <Param ControlIndex="5">0</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="0" POS="7" BypassState="1"></Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Live N Dangerous" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="1" HeelSetting="32768" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/77_Still of the Nite.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/77_Still of the Nite.fuse
@@ -1,0 +1,91 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="94" POS="0" BypassState="1">
+      <Param ControlIndex="0">43520</Param>
+      <Param ControlIndex="1">65280</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32000</Param>
+      <Param ControlIndex="4">64512</Param>
+      <Param ControlIndex="5">44544</Param>
+      <Param ControlIndex="6">59904</Param>
+      <Param ControlIndex="7">33536</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">9</Param>
+      <Param ControlIndex="13">9</Param>
+      <Param ControlIndex="14">9</Param>
+      <Param ControlIndex="15">3</Param>
+      <Param ControlIndex="16">4</Param>
+      <Param ControlIndex="17">6</Param>
+      <Param ControlIndex="18">9</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="60" POS="0" BypassState="1">
+        <Param ControlIndex="0">55296</Param>
+        <Param ControlIndex="1">44800</Param>
+        <Param ControlIndex="2">40704</Param>
+        <Param ControlIndex="3">37632</Param>
+        <Param ControlIndex="4">45056</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="18" POS="5" BypassState="1">
+        <Param ControlIndex="0">20224</Param>
+        <Param ControlIndex="1">8448</Param>
+        <Param ControlIndex="2">5120</Param>
+        <Param ControlIndex="3">6400</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="43" POS="6" BypassState="0">
+        <Param ControlIndex="0">28928</Param>
+        <Param ControlIndex="1">28160</Param>
+        <Param ControlIndex="2">4864</Param>
+        <Param ControlIndex="3">27904</Param>
+        <Param ControlIndex="4">16128</Param>
+        <Param ControlIndex="5">0</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="75" POS="7" BypassState="1">
+        <Param ControlIndex="0">18432</Param>
+        <Param ControlIndex="1">38656</Param>
+        <Param ControlIndex="2">42496</Param>
+        <Param ControlIndex="3">29696</Param>
+        <Param ControlIndex="4">17664</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Still of the Nite" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="3" HeelSetting="16384" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/78_Cold Sweat.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/78_Cold Sweat.fuse
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="121" POS="0" BypassState="1">
+      <Param ControlIndex="0">43520</Param>
+      <Param ControlIndex="1">65280</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32000</Param>
+      <Param ControlIndex="4">40192</Param>
+      <Param ControlIndex="5">65280</Param>
+      <Param ControlIndex="6">54016</Param>
+      <Param ControlIndex="7">28416</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">0</Param>
+      <Param ControlIndex="10">36864</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">11</Param>
+      <Param ControlIndex="13">11</Param>
+      <Param ControlIndex="14">11</Param>
+      <Param ControlIndex="15">1</Param>
+      <Param ControlIndex="16">2</Param>
+      <Param ControlIndex="17">10</Param>
+      <Param ControlIndex="18">11</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="60" POS="0" BypassState="1">
+        <Param ControlIndex="0">55296</Param>
+        <Param ControlIndex="1">43776</Param>
+        <Param ControlIndex="2">32512</Param>
+        <Param ControlIndex="3">39936</Param>
+        <Param ControlIndex="4">28672</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="0"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="42" POS="6" BypassState="1">
+        <Param ControlIndex="0">16384</Param>
+        <Param ControlIndex="1">25600</Param>
+        <Param ControlIndex="2">6656</Param>
+        <Param ControlIndex="3">25344</Param>
+        <Param ControlIndex="4">43264</Param>
+        <Param ControlIndex="5">32768</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="0" POS="7" BypassState="1"></Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Cold Sweat" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="4" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="2" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/79_Active Clean.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/79_Active Clean.fuse
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="117" POS="0" BypassState="1">
+      <Param ControlIndex="0">56832</Param>
+      <Param ControlIndex="1">16896</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">25344</Param>
+      <Param ControlIndex="4">29184</Param>
+      <Param ControlIndex="5">34048</Param>
+      <Param ControlIndex="6">20224</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">0</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">5</Param>
+      <Param ControlIndex="13">5</Param>
+      <Param ControlIndex="14">5</Param>
+      <Param ControlIndex="15">1</Param>
+      <Param ControlIndex="16">2</Param>
+      <Param ControlIndex="17">9</Param>
+      <Param ControlIndex="18">5</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="7" POS="0" BypassState="1">
+        <Param ControlIndex="0">21504</Param>
+        <Param ControlIndex="1">3840</Param>
+        <Param ControlIndex="2">20224</Param>
+        <Param ControlIndex="3">32512</Param>
+        <Param ControlIndex="4">32512</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="43" POS="6" BypassState="1">
+        <Param ControlIndex="0">18944</Param>
+        <Param ControlIndex="1">13568</Param>
+        <Param ControlIndex="2">7168</Param>
+        <Param ControlIndex="3">39680</Param>
+        <Param ControlIndex="4">17408</Param>
+        <Param ControlIndex="5">0</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="58" POS="7" BypassState="1">
+        <Param ControlIndex="0">26112</Param>
+        <Param ControlIndex="1">32768</Param>
+        <Param ControlIndex="2">26368</Param>
+        <Param ControlIndex="3">39680</Param>
+        <Param ControlIndex="4">65280</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Active Clean" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="4" HeelSetting="16384" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/80_British Invasion.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/80_British Invasion.fuse
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="97" POS="0" BypassState="1">
+      <Param ControlIndex="0">31488</Param>
+      <Param ControlIndex="1">23040</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">41472</Param>
+      <Param ControlIndex="4">41472</Param>
+      <Param ControlIndex="5">32768</Param>
+      <Param ControlIndex="6">45056</Param>
+      <Param ControlIndex="7">0</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">7</Param>
+      <Param ControlIndex="13">7</Param>
+      <Param ControlIndex="14">7</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">7</Param>
+      <Param ControlIndex="18">7</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="75" POS="7" BypassState="1">
+        <Param ControlIndex="0">14336</Param>
+        <Param ControlIndex="1">32768</Param>
+        <Param ControlIndex="2">37120</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">46592</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="British Invasion" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="5" HeelSetting="8192" ToeSetting="32512" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/81_Old Metal Clean.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/81_Old Metal Clean.fuse
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="97" POS="0" BypassState="1">
+      <Param ControlIndex="0">48128</Param>
+      <Param ControlIndex="1">19968</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">52480</Param>
+      <Param ControlIndex="4">43776</Param>
+      <Param ControlIndex="5">32768</Param>
+      <Param ControlIndex="6">26880</Param>
+      <Param ControlIndex="7">0</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">7</Param>
+      <Param ControlIndex="13">7</Param>
+      <Param ControlIndex="14">7</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">12</Param>
+      <Param ControlIndex="18">7</Param>
+      <Param ControlIndex="19">2</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="43" POS="6" BypassState="1">
+        <Param ControlIndex="0">18944</Param>
+        <Param ControlIndex="1">26112</Param>
+        <Param ControlIndex="2">3072</Param>
+        <Param ControlIndex="3">0</Param>
+        <Param ControlIndex="4">32768</Param>
+        <Param ControlIndex="5">0</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="75" POS="7" BypassState="1">
+        <Param ControlIndex="0">15872</Param>
+        <Param ControlIndex="1">32768</Param>
+        <Param ControlIndex="2">37120</Param>
+        <Param ControlIndex="3">32768</Param>
+        <Param ControlIndex="4">46592</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Old Metal Clean" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="4" HeelSetting="12288" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/82_Delayed Princeton.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/82_Delayed Princeton.fuse
@@ -1,0 +1,91 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="106" POS="0" BypassState="1">
+      <Param ControlIndex="0">43520</Param>
+      <Param ControlIndex="1">19968</Param>
+      <Param ControlIndex="2">0</Param>
+      <Param ControlIndex="3">65280</Param>
+      <Param ControlIndex="4">39168</Param>
+      <Param ControlIndex="5">52224</Param>
+      <Param ControlIndex="6">19456</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">4</Param>
+      <Param ControlIndex="13">4</Param>
+      <Param ControlIndex="14">4</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">4</Param>
+      <Param ControlIndex="18">4</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="7" POS="0" BypassState="1">
+        <Param ControlIndex="0">28160</Param>
+        <Param ControlIndex="1">13312</Param>
+        <Param ControlIndex="2">18944</Param>
+        <Param ControlIndex="3">32512</Param>
+        <Param ControlIndex="4">32512</Param>
+      </Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="79" POS="1" BypassState="0">
+        <Param ControlIndex="0">64768</Param>
+        <Param ControlIndex="1">0</Param>
+        <Param ControlIndex="2">64768</Param>
+        <Param ControlIndex="3">47104</Param>
+        <Param ControlIndex="4">0</Param>
+      </Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="43" POS="6" BypassState="1">
+        <Param ControlIndex="0">16896</Param>
+        <Param ControlIndex="1">27136</Param>
+        <Param ControlIndex="2">18944</Param>
+        <Param ControlIndex="3">25344</Param>
+        <Param ControlIndex="4">56064</Param>
+        <Param ControlIndex="5">0</Param>
+      </Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="11" POS="7" BypassState="1">
+        <Param ControlIndex="0">13056</Param>
+        <Param ControlIndex="1">32512</Param>
+        <Param ControlIndex="2">16896</Param>
+        <Param ControlIndex="3">65280</Param>
+        <Param ControlIndex="4">32768</Param>
+      </Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Delayed Princeton" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="4" HeelSetting="0" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="2" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/83_Basic Studio Pre.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/83_Basic Studio Pre.fuse
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="241" POS="0" BypassState="1">
+      <Param ControlIndex="0">65280</Param>
+      <Param ControlIndex="1">33024</Param>
+      <Param ControlIndex="2">33024</Param>
+      <Param ControlIndex="3">33024</Param>
+      <Param ControlIndex="4">33024</Param>
+      <Param ControlIndex="5">33024</Param>
+      <Param ControlIndex="6">33024</Param>
+      <Param ControlIndex="7">33024</Param>
+      <Param ControlIndex="8">33024</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">33024</Param>
+      <Param ControlIndex="11">33024</Param>
+      <Param ControlIndex="12">4</Param>
+      <Param ControlIndex="13">13</Param>
+      <Param ControlIndex="14">13</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">0</Param>
+      <Param ControlIndex="18">13</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="0"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="2" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Basic Studio Pre" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="0" HeelSetting="16384" ToeSetting="32768" PedalMode="0" BypassEffectWhenVolumeMode="1" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/84_Basic '57 Champ.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/84_Basic '57 Champ.fuse
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="124" POS="0" BypassState="1">
+      <Param ControlIndex="0">43520</Param>
+      <Param ControlIndex="1">45824</Param>
+      <Param ControlIndex="2">0</Param>
+      <Param ControlIndex="3">65280</Param>
+      <Param ControlIndex="4">32768</Param>
+      <Param ControlIndex="5">32768</Param>
+      <Param ControlIndex="6">32768</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">12</Param>
+      <Param ControlIndex="13">12</Param>
+      <Param ControlIndex="14">12</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">5</Param>
+      <Param ControlIndex="18">12</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="0" POS="7" BypassState="1"></Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Basic '57 Champ" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="1" HeelSetting="20480" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/85_Basic '57 Deluxe.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/85_Basic '57 Deluxe.fuse
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="103" POS="0" BypassState="1">
+      <Param ControlIndex="0">43520</Param>
+      <Param ControlIndex="1">39168</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32768</Param>
+      <Param ControlIndex="4">48640</Param>
+      <Param ControlIndex="5">32768</Param>
+      <Param ControlIndex="6">32768</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">1</Param>
+      <Param ControlIndex="13">1</Param>
+      <Param ControlIndex="14">1</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">1</Param>
+      <Param ControlIndex="18">1</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="0" POS="7" BypassState="1"></Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Basic '57 Deluxe" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="1" HeelSetting="20480" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/86_Basic '57 Twin.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/86_Basic '57 Twin.fuse
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="246" POS="0" BypassState="1">
+      <Param ControlIndex="0">44032</Param>
+      <Param ControlIndex="1">19968</Param>
+      <Param ControlIndex="2">33024</Param>
+      <Param ControlIndex="3">33024</Param>
+      <Param ControlIndex="4">44032</Param>
+      <Param ControlIndex="5">31488</Param>
+      <Param ControlIndex="6">40192</Param>
+      <Param ControlIndex="7">48384</Param>
+      <Param ControlIndex="8">33024</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">33024</Param>
+      <Param ControlIndex="11">33024</Param>
+      <Param ControlIndex="12">4</Param>
+      <Param ControlIndex="13">14</Param>
+      <Param ControlIndex="14">14</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">9</Param>
+      <Param ControlIndex="18">14</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="0"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="2" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Basic '57 Twin" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="0" HeelSetting="16384" ToeSetting="32768" PedalMode="0" BypassEffectWhenVolumeMode="1" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/87_Basic '59 Bassman.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/87_Basic '59 Bassman.fuse
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="100" POS="0" BypassState="1">
+      <Param ControlIndex="0">43520</Param>
+      <Param ControlIndex="1">41472</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32768</Param>
+      <Param ControlIndex="4">32768</Param>
+      <Param ControlIndex="5">31232</Param>
+      <Param ControlIndex="6">41472</Param>
+      <Param ControlIndex="7">37120</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">2</Param>
+      <Param ControlIndex="13">2</Param>
+      <Param ControlIndex="14">2</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">2</Param>
+      <Param ControlIndex="18">2</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="0" POS="7" BypassState="1"></Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Basic '59 Bassman" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="1" HeelSetting="24576" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/88_Basic 65Princeton.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/88_Basic 65Princeton.fuse
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="106" POS="0" BypassState="1">
+      <Param ControlIndex="0">43520</Param>
+      <Param ControlIndex="1">21760</Param>
+      <Param ControlIndex="2">0</Param>
+      <Param ControlIndex="3">65280</Param>
+      <Param ControlIndex="4">39168</Param>
+      <Param ControlIndex="5">52224</Param>
+      <Param ControlIndex="6">19456</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">4</Param>
+      <Param ControlIndex="13">4</Param>
+      <Param ControlIndex="14">4</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">4</Param>
+      <Param ControlIndex="18">4</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="0" POS="7" BypassState="1"></Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Basic 65Princeton" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="1" HeelSetting="20480" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/89_Basic '65 Deluxe.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/89_Basic '65 Deluxe.fuse
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="83" POS="0" BypassState="1">
+      <Param ControlIndex="0">43520</Param>
+      <Param ControlIndex="1">28928</Param>
+      <Param ControlIndex="2">0</Param>
+      <Param ControlIndex="3">65280</Param>
+      <Param ControlIndex="4">37120</Param>
+      <Param ControlIndex="5">52992</Param>
+      <Param ControlIndex="6">14336</Param>
+      <Param ControlIndex="7">0</Param>
+      <Param ControlIndex="8">0</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">0</Param>
+      <Param ControlIndex="12">3</Param>
+      <Param ControlIndex="13">3</Param>
+      <Param ControlIndex="14">3</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">3</Param>
+      <Param ControlIndex="18">3</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="0" POS="7" BypassState="1"></Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Basic '65 Deluxe" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="1" HeelSetting="24576" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/90_Basic '65 Twin.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/90_Basic '65 Twin.fuse
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="117" POS="0" BypassState="1">
+      <Param ControlIndex="0">43520</Param>
+      <Param ControlIndex="1">22272</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">25344</Param>
+      <Param ControlIndex="4">45824</Param>
+      <Param ControlIndex="5">47872</Param>
+      <Param ControlIndex="6">43520</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">5</Param>
+      <Param ControlIndex="13">5</Param>
+      <Param ControlIndex="14">5</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">9</Param>
+      <Param ControlIndex="18">5</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="0" POS="7" BypassState="1"></Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Basic '65 Twin" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="1" HeelSetting="20480" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/91_Basic '60s Thrift.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/91_Basic '60s Thrift.fuse
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="249" POS="0" BypassState="1">
+      <Param ControlIndex="0">41728</Param>
+      <Param ControlIndex="1">33024</Param>
+      <Param ControlIndex="2">33024</Param>
+      <Param ControlIndex="3">33024</Param>
+      <Param ControlIndex="4">44032</Param>
+      <Param ControlIndex="5">57088</Param>
+      <Param ControlIndex="6">40192</Param>
+      <Param ControlIndex="7">33024</Param>
+      <Param ControlIndex="8">33024</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">33024</Param>
+      <Param ControlIndex="11">33024</Param>
+      <Param ControlIndex="12">4</Param>
+      <Param ControlIndex="13">15</Param>
+      <Param ControlIndex="14">15</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">1</Param>
+      <Param ControlIndex="18">15</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="0"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="2" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Basic '60s Thrift" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="0" HeelSetting="16384" ToeSetting="32768" PedalMode="0" BypassEffectWhenVolumeMode="1" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/92_Basic Brit Watts.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/92_Basic Brit Watts.fuse
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="255" POS="0" BypassState="1">
+      <Param ControlIndex="0">47616</Param>
+      <Param ControlIndex="1">40192</Param>
+      <Param ControlIndex="2">33024</Param>
+      <Param ControlIndex="3">65280</Param>
+      <Param ControlIndex="4">47616</Param>
+      <Param ControlIndex="5">38912</Param>
+      <Param ControlIndex="6">42496</Param>
+      <Param ControlIndex="7">34560</Param>
+      <Param ControlIndex="8">33024</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">33024</Param>
+      <Param ControlIndex="11">33024</Param>
+      <Param ControlIndex="12">4</Param>
+      <Param ControlIndex="13">17</Param>
+      <Param ControlIndex="14">17</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">10</Param>
+      <Param ControlIndex="18">17</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="0"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="2" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Basic Brit Watts" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="0" HeelSetting="16384" ToeSetting="32768" PedalMode="0" BypassEffectWhenVolumeMode="1" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/93_Basic British 60s.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/93_Basic British 60s.fuse
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="97" POS="0" BypassState="1">
+      <Param ControlIndex="0">43520</Param>
+      <Param ControlIndex="1">41472</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">25344</Param>
+      <Param ControlIndex="4">39168</Param>
+      <Param ControlIndex="5">32768</Param>
+      <Param ControlIndex="6">45056</Param>
+      <Param ControlIndex="7">0</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">7</Param>
+      <Param ControlIndex="13">7</Param>
+      <Param ControlIndex="14">7</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">7</Param>
+      <Param ControlIndex="18">7</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="0" POS="7" BypassState="1"></Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Basic British 60s" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="1" HeelSetting="20480" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/94_Basic British 70s.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/94_Basic British 70s.fuse
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="121" POS="0" BypassState="1">
+      <Param ControlIndex="0">43520</Param>
+      <Param ControlIndex="1">65280</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32000</Param>
+      <Param ControlIndex="4">43520</Param>
+      <Param ControlIndex="5">23296</Param>
+      <Param ControlIndex="6">50176</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">0</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">11</Param>
+      <Param ControlIndex="13">11</Param>
+      <Param ControlIndex="14">11</Param>
+      <Param ControlIndex="15">1</Param>
+      <Param ControlIndex="16">2</Param>
+      <Param ControlIndex="17">8</Param>
+      <Param ControlIndex="18">11</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="0" POS="7" BypassState="1"></Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Basic British 70s" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="1" HeelSetting="12288" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/95_Basic British 80s.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/95_Basic British 80s.fuse
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="94" POS="0" BypassState="1">
+      <Param ControlIndex="0">43520</Param>
+      <Param ControlIndex="1">65280</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">32000</Param>
+      <Param ControlIndex="4">43520</Param>
+      <Param ControlIndex="5">23296</Param>
+      <Param ControlIndex="6">50176</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">0</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">9</Param>
+      <Param ControlIndex="13">9</Param>
+      <Param ControlIndex="14">9</Param>
+      <Param ControlIndex="15">1</Param>
+      <Param ControlIndex="16">2</Param>
+      <Param ControlIndex="17">6</Param>
+      <Param ControlIndex="18">9</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="0" POS="7" BypassState="1"></Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Basic British 80s" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="1" HeelSetting="8192" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/96_Basic Brit Colour.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/96_Basic Brit Colour.fuse
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="252" POS="0" BypassState="1">
+      <Param ControlIndex="0">38656</Param>
+      <Param ControlIndex="1">35840</Param>
+      <Param ControlIndex="2">33024</Param>
+      <Param ControlIndex="3">33024</Param>
+      <Param ControlIndex="4">40192</Param>
+      <Param ControlIndex="5">25600</Param>
+      <Param ControlIndex="6">33024</Param>
+      <Param ControlIndex="7">33024</Param>
+      <Param ControlIndex="8">33024</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">33024</Param>
+      <Param ControlIndex="11">33024</Param>
+      <Param ControlIndex="12">4</Param>
+      <Param ControlIndex="13">16</Param>
+      <Param ControlIndex="14">16</Param>
+      <Param ControlIndex="15">0</Param>
+      <Param ControlIndex="16">0</Param>
+      <Param ControlIndex="17">8</Param>
+      <Param ControlIndex="18">16</Param>
+      <Param ControlIndex="19">0</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="0"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="2" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Basic Brit Colour" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="0" HeelSetting="16384" ToeSetting="32768" PedalMode="0" BypassEffectWhenVolumeMode="1" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="0" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/97_Basic Super-Sonic.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/97_Basic Super-Sonic.fuse
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="114" POS="0" BypassState="1">
+      <Param ControlIndex="0">53504</Param>
+      <Param ControlIndex="1">47872</Param>
+      <Param ControlIndex="2">33280</Param>
+      <Param ControlIndex="3">21760</Param>
+      <Param ControlIndex="4">39168</Param>
+      <Param ControlIndex="5">41472</Param>
+      <Param ControlIndex="6">39168</Param>
+      <Param ControlIndex="7">32768</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">6</Param>
+      <Param ControlIndex="13">6</Param>
+      <Param ControlIndex="14">6</Param>
+      <Param ControlIndex="15">2</Param>
+      <Param ControlIndex="16">3</Param>
+      <Param ControlIndex="17">12</Param>
+      <Param ControlIndex="18">6</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="0" POS="7" BypassState="1"></Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Basic Super-Sonic" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="1" HeelSetting="12288" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/98_Basic 90s Stack.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/98_Basic 90s Stack.fuse
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="93" POS="0" BypassState="1">
+      <Param ControlIndex="0">53248</Param>
+      <Param ControlIndex="1">36352</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">26112</Param>
+      <Param ControlIndex="4">41984</Param>
+      <Param ControlIndex="5">6400</Param>
+      <Param ControlIndex="6">50944</Param>
+      <Param ControlIndex="7">28928</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">10</Param>
+      <Param ControlIndex="13">10</Param>
+      <Param ControlIndex="14">10</Param>
+      <Param ControlIndex="15">3</Param>
+      <Param ControlIndex="16">4</Param>
+      <Param ControlIndex="17">10</Param>
+      <Param ControlIndex="18">10</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="0" POS="7" BypassState="1"></Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Basic 90s Stack" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="1" HeelSetting="16384" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/99_Basic 2000 Metal.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/Presets/99_Basic 2000 Metal.fuse
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Preset amplifier="Mustang V2 III/IV/V" ProductId="13">
+  <Amplifier>
+    <Module ID="109" POS="0" BypassState="1">
+      <Param ControlIndex="0">49920</Param>
+      <Param ControlIndex="1">41984</Param>
+      <Param ControlIndex="2">32768</Param>
+      <Param ControlIndex="3">21760</Param>
+      <Param ControlIndex="4">39168</Param>
+      <Param ControlIndex="5">19456</Param>
+      <Param ControlIndex="6">37120</Param>
+      <Param ControlIndex="7">36352</Param>
+      <Param ControlIndex="8">32768</Param>
+      <Param ControlIndex="9">65535</Param>
+      <Param ControlIndex="10">32768</Param>
+      <Param ControlIndex="11">32768</Param>
+      <Param ControlIndex="12">8</Param>
+      <Param ControlIndex="13">8</Param>
+      <Param ControlIndex="14">8</Param>
+      <Param ControlIndex="15">2</Param>
+      <Param ControlIndex="16">3</Param>
+      <Param ControlIndex="17">8</Param>
+      <Param ControlIndex="18">8</Param>
+      <Param ControlIndex="19">1</Param>
+      <Param ControlIndex="20">0</Param>
+      <Param ControlIndex="21">1</Param>
+      <Param ControlIndex="22">0</Param>
+    </Module>
+  </Amplifier>
+  <FX>
+    <Stompbox ID="1">
+      <Module ID="0" POS="0" BypassState="1"></Module>
+    </Stompbox>
+    <Modulation ID="2">
+      <Module ID="0" POS="5" BypassState="1"></Module>
+    </Modulation>
+    <Delay ID="3">
+      <Module ID="0" POS="6" BypassState="1"></Module>
+    </Delay>
+    <Reverb ID="4">
+      <Module ID="0" POS="7" BypassState="1"></Module>
+    </Reverb>
+  </FX>
+  <Band Type="0" Repeat="0">
+    <SongFile Location="6">No Band</SongFile>
+    <AudioMix>0</AudioMix>
+    <Balance>29127</Balance>
+    <Speed>100</Speed>
+    <Pitch>0</Pitch>
+    <Tempo />
+    <Transpose />
+    <DrumSolo />
+    <CountIn />
+  </Band>
+  <FUSE>
+    <Info name="Basic 2000 Metal" author="Fender FUSE" rating="0" genre1="-1" genre2="-1" genre3="-1" tags="" fenderid="0"></Info>
+    <PedalColors>
+      <Color ID="1">14</Color>
+      <Color ID="2">1</Color>
+      <Color ID="3">2</Color>
+      <Color ID="4">10</Color>
+    </PedalColors>
+  </FUSE>
+  <FirstExpressionPedal VolumeModeBehavior="1" ExpressionModeBehavior="1" HeelSetting="16384" ToeSetting="65280" PedalMode="0" BypassEffectWhenVolumeMode="0" VolumeSwitchRevert="0" DefaultPedalState="0" PedalOverrideState="1" ParameterIndex="1" />
+  <UsbGain>0</UsbGain>
+</Preset>

--- a/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/SystemSettings.fuse
+++ b/SampleBackups/Mustang3V2_Fuse270/2013_05_09_16_50_38/SystemSettings.fuse
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<System>
+  <QA>0</QA>
+  <QA>1</QA>
+  <QA>2</QA>
+  <QA>3</QA>
+  <QA>4</QA>
+  <QA>5</QA>
+  <QA>6</QA>
+  <QA>7</QA>
+  <QA>8</QA>
+  <QA>9</QA>
+  <QA>10</QA>
+  <QA>11</QA>
+  <QA>12</QA>
+  <QA>13</QA>
+  <QA>14</QA>
+  <QA>15</QA>
+  <LCDContrast>112</LCDContrast>
+  <MemoryLock>0</MemoryLock>
+  <Foot2BtnMode>0</Foot2BtnMode>
+  <ExpPedalVolumeHeel>0</ExpPedalVolumeHeel>
+  <ExpPedalVolumeToe>255</ExpPedalVolumeToe>
+  <Foot4BtnMode>0</Foot4BtnMode>
+</System>

--- a/SpeedShop/SpeedShop/MFAppDelegate.m
+++ b/SpeedShop/SpeedShop/MFAppDelegate.m
@@ -386,7 +386,7 @@
     [self.authorNameField setStringValue:self.currentPreset.author ?: @""];
     [self.presetDescriptionField setStringValue:self.currentPreset.description ?: @""];
     
-    if (self.currentBackup.ampSeries == AmpSeries_Mustang)
+    if (self.currentBackup.ampSeries == AmpSeries_Mustang || self.currentBackup.ampSeries == AmpSeries_Mustang_V2)
     {
         self.qaBox1.preset = [self.currentBackup presetForQASlot:0] ?: nil;
         self.qaBox2.preset = [self.currentBackup presetForQASlot:1] ?: nil;

--- a/SpeedShop/SpeedShop/MFFuseBackup.h
+++ b/SpeedShop/SpeedShop/MFFuseBackup.h
@@ -15,7 +15,8 @@ typedef void (^MFFuseBackupSaveCompletion)(BOOL, NSURL*);
 typedef enum
 {
     AmpSeries_Mustang,
-    AmpSeries_GDec
+    AmpSeries_GDec,
+    AmpSeries_Mustang_V2
 } AmpSeries;
 
 @interface MFFuseBackup : NSObject <NSXMLParserDelegate>

--- a/SpeedShop/SpeedShop/MFFuseBackup.m
+++ b/SpeedShop/SpeedShop/MFFuseBackup.m
@@ -13,6 +13,7 @@ NSString *FUSE_FOLDER = @"FUSE";
 NSString *PRESET_FOLDER = @"Presets";
 NSString *BACKUP_FILENAME_GDEC = @"GD_BackupName.fuse";
 NSString *BACKUP_FILENAME_MUSTANG = @"MU_BackupName.fuse";
+NSString *BACKUP_FILENAME_MUSTANG_V2 = @"M2_BackupName.fuse";
 NSString *SETTINGS_FILENAME = @"SystemSettings.fuse";
 
 @interface MFFuseBackup()
@@ -62,7 +63,7 @@ NSString *SETTINGS_FILENAME = @"SystemSettings.fuse";
     // We should have four items:
     // - "FUSE" folder
     // - "Presets" folder
-    // - "MU_BackupName.fuse" file or "GD_BackupName.fuse"
+    // - "MU_BackupName.fuse" or "M2_BackupName.fuse" or "GD_BackupName.fuse" file
     // - "SystemSettings.fuse" file - Mustang only
     
     NSFileManager *fileMan = [NSFileManager defaultManager];
@@ -96,6 +97,13 @@ NSString *SETTINGS_FILENAME = @"SystemSettings.fuse";
         _ampSeries = AmpSeries_Mustang;
     }
     
+    NSURL *backupFileMustang_V2 = [_folderURL URLByAppendingPathComponent:BACKUP_FILENAME_MUSTANG_V2];
+    if ([fileMan fileExistsAtPath:[backupFileMustang_V2 path]] == YES)
+    {
+        backupFileFound = YES;
+        _ampSeries = AmpSeries_Mustang_V2;
+    }
+    
     NSURL *backupFileGDec = [_folderURL URLByAppendingPathComponent:BACKUP_FILENAME_GDEC];
     if ([fileMan fileExistsAtPath:[backupFileGDec path]] == YES)
     {
@@ -107,7 +115,7 @@ NSString *SETTINGS_FILENAME = @"SystemSettings.fuse";
         return NO;
     
     // Look for a settings file if it's a Mustang series
-    if (_ampSeries == AmpSeries_Mustang)
+    if (_ampSeries == AmpSeries_Mustang || _ampSeries == AmpSeries_Mustang_V2)
     {
         NSURL *settingsFile = [_folderURL URLByAppendingPathComponent:SETTINGS_FILENAME];
         if ([fileMan fileExistsAtPath:[settingsFile path]] == NO)
@@ -132,6 +140,9 @@ NSString *SETTINGS_FILENAME = @"SystemSettings.fuse";
     NSString *fileName = nil;
     if (_ampSeries == AmpSeries_Mustang)
         fileName = BACKUP_FILENAME_MUSTANG;
+    
+    if (_ampSeries == AmpSeries_Mustang_V2)
+        fileName = BACKUP_FILENAME_MUSTANG_V2;
     
     if (_ampSeries == AmpSeries_GDec)
         fileName = BACKUP_FILENAME_GDEC;
@@ -293,6 +304,9 @@ NSString *SETTINGS_FILENAME = @"SystemSettings.fuse";
     if (_ampSeries == AmpSeries_Mustang)
         backupFileName = BACKUP_FILENAME_MUSTANG;
     
+    if (_ampSeries == AmpSeries_Mustang_V2)
+        backupFileName = BACKUP_FILENAME_MUSTANG_V2;
+
     if (_ampSeries == AmpSeries_GDec)
         backupFileName = BACKUP_FILENAME_GDEC;
     
@@ -308,7 +322,7 @@ NSString *SETTINGS_FILENAME = @"SystemSettings.fuse";
     }
     
     // Saving of the settings file
-    if (_ampSeries == AmpSeries_Mustang)
+    if (_ampSeries == AmpSeries_Mustang || _ampSeries == AmpSeries_Mustang_V2)
     {
         NSURL *settingsFile = [_folderURL URLByAppendingPathComponent:SETTINGS_FILENAME];
         NSXMLDocument *settingsXML = [[NSXMLDocument alloc] initWithContentsOfURL:settingsFile

--- a/SpeedShop/SpeedShop/ReleaseNotes.txt
+++ b/SpeedShop/SpeedShop/ReleaseNotes.txt
@@ -25,3 +25,7 @@ Release Notes
 
 # 0.9.1
 * Added G-Dec support
+
+# 0.9.2
+* Added Mustang V.2 support
+

--- a/SpeedShop/SpeedShop/Speed Shop-Info.plist
+++ b/SpeedShop/SpeedShop/Speed Shop-Info.plist
@@ -19,11 +19,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.1</string>
+	<string>0.9.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>1</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.music</string>
 	<key>LSMinimumSystemVersion</key>

--- a/SpeedShop/SpeedShopTests/Horse_WhispererTests.m
+++ b/SpeedShop/SpeedShopTests/Horse_WhispererTests.m
@@ -14,6 +14,7 @@
 {
     NSURL *sampleBackupDir;
     NSURL *fuse270dir;
+    NSURL *fuse270_mustangV2_dir;
     NSURL *gdec30dir;
 }
 
@@ -29,7 +30,9 @@
     sampleBackupDir = [[NSBundle mainBundle] URLForResource:@"SampleBackups" withExtension:nil];
     
     fuse270dir = [sampleBackupDir URLByAppendingPathComponent:@"Mustang3_Fuse270/2013_02_27_21_09_59/"];
+    fuse270_mustangV2_dir = [sampleBackupDir URLByAppendingPathComponent:@"Mustang3V2_Fuse270/2013_05_09_16_50_38/"];
     gdec30dir = [sampleBackupDir URLByAppendingPathComponent:@"GDEC_30/2013_02_17_19_24_50/"];
+    
 }
 
 - (void)tearDown
@@ -44,6 +47,7 @@
     NSFileManager *fileMan = [NSFileManager defaultManager];
     STAssertTrue([fileMan fileExistsAtPath:[fuse270dir path]], @"Sample backup not found - fuse270");
     STAssertTrue([fileMan fileExistsAtPath:[gdec30dir path]], @"Sample backup not found - G-Dec 30");
+    STAssertTrue([fileMan fileExistsAtPath:[fuse270_mustangV2_dir path]], @"Sample backup not found - fuse270_Mustang3V2");
 }
 
 - (void) testMustangLoad
@@ -57,6 +61,19 @@
         STAssertTrue([backup.presets count] == 100, @"Failed to find 100 presets");
     }];
 }
+
+- (void) testMustangV2Load
+{
+    MFFuseBackup *backup = [[MFFuseBackup alloc] init];
+    [backup loadBackup:fuse270_mustangV2_dir withCompletion:^(BOOL success) {
+        STAssertTrue(success, @"Failed to load backup");
+        
+        STAssertTrue([backup.backupDescription isEqualToString:@"TestBackup - Mustang 3 V.2 - Fuse 2.7"], @"Failed to load backup name");
+        
+        STAssertTrue([backup.presets count] == 100, @"Failed to find 100 presets");
+    }];
+}
+
 
 - (void) testGDecLoad
 {
@@ -75,6 +92,10 @@
     MFFuseBackup *mustangBackup = [[MFFuseBackup alloc] init];
     mustangBackup.folderURL = fuse270dir;
     STAssertTrue([mustangBackup validateBackupContents], @"Validation of sample contents failed - Mustang");
+
+    MFFuseBackup *mustangV2Backup = [[MFFuseBackup alloc] init];
+    mustangV2Backup.folderURL = fuse270_mustangV2_dir;
+    STAssertTrue([mustangBackup validateBackupContents], @"Validation of sample contents failed - Mustang V.2");
     
     MFFuseBackup *gDecBackup = [[MFFuseBackup alloc] init];
     gDecBackup.folderURL = gdec30dir;


### PR DESCRIPTION
Mustang V.2 series stores backup comments in a file named
"M2_BackupName.fuse" (instead if MU_BackupName.fuse of the V.1 series).
So the previous version of Speed Shop refused loading such backups.
